### PR TITLE
[FE] FIX: MultiToggleSwitch 이 페이지 전체 button 에 영향을 주지 못하도록 수정#1512

### DIFF
--- a/frontend/src/components/Common/MultiToggleSwitch.tsx
+++ b/frontend/src/components/Common/MultiToggleSwitch.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import styled from "styled-components";
 
-interface toggleItem {
+export interface toggleItem {
   name: string;
   key: string;
 }
@@ -17,10 +17,12 @@ const MultiToggleSwitch = <T,>({
   setState,
   toggleList,
 }: MultiToggleSwitchProps<T>) => {
-  useEffect(() => {
-    const buttons = document.querySelectorAll("button");
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
-    buttons.forEach((button) => {
+  useEffect(() => {
+    const buttons = wrapperRef.current?.querySelectorAll("button");
+
+    buttons?.forEach((button) => {
       if (button.className === initialState) {
         button.style.color = "white";
         button.style.backgroundColor = "var(--main-color)";
@@ -29,13 +31,13 @@ const MultiToggleSwitch = <T,>({
   }, []);
 
   function switchToggle(e: any) {
-    const target = e.target;
+    const target = e.target as HTMLButtonElement;
 
     if (target === e.currentTarget) return;
 
-    const buttons = document.querySelectorAll("button");
+    const buttons = wrapperRef.current?.querySelectorAll("button");
 
-    buttons.forEach((button) => {
+    buttons?.forEach((button) => {
       button.style.color = "black";
       button.style.backgroundColor = "transparent";
     });
@@ -43,11 +45,11 @@ const MultiToggleSwitch = <T,>({
     target.style.color = "white";
     target.style.backgroundColor = "var(--main-color)";
 
-    setState(target.className);
+    setState(target.className as React.SetStateAction<T>);
   }
 
   return (
-    <WrapperStyled onClick={switchToggle}>
+    <WrapperStyled ref={wrapperRef} onClick={switchToggle}>
       {toggleList.map((item) => (
         <button key={item.key} className={item.key}>
           {item.name}

--- a/frontend/src/components/Modals/PasswordCheckModal/PasswordContainer.tsx
+++ b/frontend/src/components/Modals/PasswordCheckModal/PasswordContainer.tsx
@@ -26,7 +26,6 @@ const PasswordContainer = ({
   }, [password]);
 
   const handleEnterPress = () => {
-    console.log(password.length);
     if (tryLentRequest && password.length == 4) tryLentRequest();
   };
 

--- a/frontend/src/pages/PendingPage/PendingPage.tsx
+++ b/frontend/src/pages/PendingPage/PendingPage.tsx
@@ -5,7 +5,9 @@ import { isCurrentSectionRenderState } from "@/recoil/atoms";
 import FloorContainer from "@/pages/PendingPage/components/FloorContainer";
 import PendingCountdown from "@/pages/PendingPage/components/PendingCountdown";
 import LoadingAnimation from "@/components/Common/LoadingAnimation";
-import MultiToggleSwitch from "@/components/Common/MultiToggleSwitch";
+import MultiToggleSwitch, {
+  toggleItem,
+} from "@/components/Common/MultiToggleSwitch";
 import {
   CabinetPreviewInfo,
   PendingCabinetsInfo,
@@ -19,7 +21,7 @@ enum PendingCabinetsType {
   SHARE = "SHARE",
 }
 
-const toggleList = [
+const toggleList: toggleItem[] = [
   { name: "전체", key: PendingCabinetsType.ALL },
   { name: "개인", key: PendingCabinetsType.PRIVATE },
   { name: "공유", key: PendingCabinetsType.SHARE },
@@ -89,11 +91,22 @@ const PendingPage = () => {
     );
   };
 
+  const updateLocalStorage = () => {
+    const recoilPersist = localStorage.getItem("recoil-persist");
+    if (recoilPersist) {
+      let recoilPersistObj = JSON.parse(recoilPersist);
+      delete recoilPersistObj.CurrentFloor;
+      delete recoilPersistObj.CurrentSection;
+      localStorage.setItem("recoil-persist", JSON.stringify(recoilPersistObj));
+    }
+  };
+
   useEffect(() => {
     setTimeout(() => {
       // 새로고침 광클 방지를 위한 초기 로딩 딜레이
       setIsLoaded(true);
     }, 500);
+    updateLocalStorage();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

- useRef 를 사용하여 MultiToggleSwitch 내의 버튼에만 style 변경이 적용되도록 MultiToggleSwitch 를 수정했습니다.
- 사용가능 페이지에서 localStorage 에 있는 층의 사물함 데이터를 요창하지 못하도록 사용가능 페이지 진입 시 층 정보를 제거했습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1512
