### PR TITLE
[HOTFIX] 1시 이후 반납된 사물함이 pending에서 안보이는 것 수정

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/cabinet/service/CabinetFacadeService.java
@@ -42,7 +42,6 @@ import org.ftclub.cabinet.mapper.CabinetMapper;
 import org.ftclub.cabinet.mapper.LentMapper;
 import org.ftclub.cabinet.user.domain.User;
 import org.ftclub.cabinet.user.service.UserQueryService;
-import org.ftclub.cabinet.utils.DateUtil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -194,13 +193,11 @@ public class CabinetFacadeService {
 				cabinetFloorMap.get(floor).add(cabinetMapper.toCabinetPreviewDto(cabinet, 0, null));
 			}
 			if (cabinet.isStatus(PENDING)) {
-				LocalDateTime latestEndedAt = lentHistoriesMap.get(cabinet.getId()).stream()
+				lentHistoriesMap.get(cabinet.getId()).stream()
 						.map(LentHistory::getEndedAt)
-						.max(LocalDateTime::compareTo).orElse(null);
-				if (latestEndedAt != null && DateUtil.isSameDay(latestEndedAt, yesterday)) {
-					cabinetFloorMap.get(floor)
-							.add(cabinetMapper.toCabinetPreviewDto(cabinet, 0, null));
-				}
+						.max(LocalDateTime::compareTo)
+						.ifPresent(latestEndedAt -> cabinetFloorMap.get(floor)
+								.add(cabinetMapper.toCabinetPreviewDto(cabinet, 0, null)));
 			}
 		});
 		return cabinetMapper.toCabinetPendingResponseDto(cabinetFloorMap);


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/

1시 이후에 반납해도 사용 가능 사물함에서 오픈 예정이 안보이는 현상 수정