### PR TITLE
[BE] FEAT: 반납일 7,3,1 일전 미리 알람주도록 기능 추가#1518

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/alarm/config/AlarmProperties.java
+++ b/backend/src/main/java/org/ftclub/cabinet/alarm/config/AlarmProperties.java
@@ -93,11 +93,11 @@ public class AlarmProperties {
 	private String announcementSlackTemplate;
 
 	/*======================== term =============================*/
-	@Value("${cabinet.alarm.overdue-term.week-ago}")
-	private Long overdueTermWeekAge;
+	@Value("${cabinet.alarm.overdue-term.week-before}")
+	private Long overdueTermWeekBefore;
 
-	@Value("${cabinet.alarm.overdue-term.three-days-ago}")
-	private Long overdueTermThreeDaysAgo;
+	@Value("${cabinet.alarm.overdue-term.three-days-before}")
+	private Long overdueTermThreeDaysBefore;
 
 	@Value("${cabinet.alarm.overdue-term.soon-overdue}")
 	private Long overdueTermSoonOverdue;

--- a/backend/src/main/java/org/ftclub/cabinet/alarm/config/AlarmProperties.java
+++ b/backend/src/main/java/org/ftclub/cabinet/alarm/config/AlarmProperties.java
@@ -38,9 +38,6 @@ public class AlarmProperties {
 	private String overdueSlackTemplate;
 
 	/*===================== soonOverdue =========================*/
-	@Value("${cabinet.alarm.mail.soonOverdue.term}")
-	private Long soonOverdueTerm;
-
 	@Value("${cabinet.alarm.mail.soonOverdue.subject}")
 	private String soonOverdueSubject;
 
@@ -94,4 +91,23 @@ public class AlarmProperties {
 
 	@Value("${cabinet.alarm.slack.announcement.template}")
 	private String announcementSlackTemplate;
+
+	/*======================== term =============================*/
+	@Value("${cabinet.alarm.overdue-term.week-ago}")
+	private Long overdueTermWeekAge;
+
+	@Value("${cabinet.alarm.overdue-term.three-days-ago}")
+	private Long overdueTermThreeDaysAgo;
+
+	@Value("${cabinet.alarm.overdue-term.soon-overdue}")
+	private Long overdueTermSoonOverdue;
+
+	@Value("${cabinet.alarm.overdue-term.overdue}")
+	private Long overdueTermOverdue;
+
+	@Value("${cabinet.alarm.overdue-term.three-days-overdue}")
+	private Long overdueTermThreeDaysOverdue;
+
+	@Value("${cabinet.alarm.overdue-term.week-overdue}")
+	private Long overdueTermWeekOverdue;
 }

--- a/backend/src/main/java/org/ftclub/cabinet/alarm/config/AlarmProperties.java
+++ b/backend/src/main/java/org/ftclub/cabinet/alarm/config/AlarmProperties.java
@@ -104,10 +104,4 @@ public class AlarmProperties {
 
 	@Value("${cabinet.alarm.overdue-term.overdue}")
 	private Long overdueTermOverdue;
-
-	@Value("${cabinet.alarm.overdue-term.three-days-overdue}")
-	private Long overdueTermThreeDaysOverdue;
-
-	@Value("${cabinet.alarm.overdue-term.week-overdue}")
-	private Long overdueTermWeekOverdue;
 }

--- a/backend/src/main/java/org/ftclub/cabinet/event/RedisExpirationEventListener.java
+++ b/backend/src/main/java/org/ftclub/cabinet/event/RedisExpirationEventListener.java
@@ -1,4 +1,4 @@
-package org.ftclub.cabinet.redis;
+package org.ftclub.cabinet.event;
 
 import lombok.extern.log4j.Log4j2;
 import org.ftclub.cabinet.lent.service.LentFacadeService;
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Log4j2
-public class ExpirationListener extends KeyExpirationEventMessageListener {
+public class RedisExpirationEventListener extends KeyExpirationEventMessageListener {
 
 	private final LentFacadeService lentFacadeService;
 
@@ -22,7 +22,7 @@ public class ExpirationListener extends KeyExpirationEventMessageListener {
 	 * @param listenerContainer must not be {@literal null}.
 	 * @param lentFacadeService must not be {@literal null}.
 	 */
-	public ExpirationListener(
+	public RedisExpirationEventListener(
 			@Qualifier("redisMessageListenerContainer")
 			RedisMessageListenerContainer listenerContainer,
 			LentFacadeService lentFacadeService) {

--- a/backend/src/main/java/org/ftclub/cabinet/utils/overdue/manager/OverdueManager.java
+++ b/backend/src/main/java/org/ftclub/cabinet/utils/overdue/manager/OverdueManager.java
@@ -42,10 +42,10 @@ public class OverdueManager {
 			return OverdueType.OVERDUE;
 		}
 
-		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermWeekAge())) {
+		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermWeekBefore())) {
 			return OverdueType.SOON_OVERDUE;
 		}
-		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermThreeDaysAgo())) {
+		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermThreeDaysBefore())) {
 			return OverdueType.SOON_OVERDUE;
 		}
 		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermSoonOverdue())) {
@@ -64,10 +64,9 @@ public class OverdueManager {
 	}
 
 	public void handleOverdue(ActiveLentHistoryDto activeLent) {
-		log.info("called handleOverdue with {}", activeLent);
 		OverdueType overdueType = getOverdueType(activeLent.getIsExpired(),
 				activeLent.getDaysLeftFromExpireDate());
-		log.info("overdueType = {}", overdueType);
+		log.info("called handleOverdue: activeLent={}, overdueType={}", activeLent, overdueType);
 		switch (overdueType) {
 			case NONE:
 				return;

--- a/backend/src/main/java/org/ftclub/cabinet/utils/overdue/manager/OverdueManager.java
+++ b/backend/src/main/java/org/ftclub/cabinet/utils/overdue/manager/OverdueManager.java
@@ -23,48 +23,64 @@ import org.springframework.stereotype.Component;
  */
 public class OverdueManager {
 
-    private final CabinetFacadeService cabinetFacadeService;
-    private final AlarmProperties alarmProperties;
-    private final ApplicationEventPublisher eventPublisher;
+	private final CabinetFacadeService cabinetFacadeService;
+	private final AlarmProperties alarmProperties;
+	private final ApplicationEventPublisher eventPublisher;
 
 
-    /**
-     * 연체 타입을 반환하는 메소드 연체 예정인 경우, SOON_OVERDUE를 반환하고, 연체 기간이 지난 경우, OVERDUE를 반환한다. 그 외의 경우, NONE을
-     * 반환한다.
-     *
-     * @param isExpired              연체 기간이 지났는지 여부 (true: 연체 기간이 지남, false: 연체 기간이 지나지 않음)
-     * @param daysLeftFromExpireDate 만료일까지 남은 일수
-     * @return 연체 타입
-     */
-    public OverdueType getOverdueType(Boolean isExpired, Long daysLeftFromExpireDate) {
-        log.info("called getOverdueType with {}, {}", isExpired, daysLeftFromExpireDate);
-        if (isExpired) {
-            return OverdueType.OVERDUE;
-        }
-        if (alarmProperties.getSoonOverdueTerm().equals(daysLeftFromExpireDate)) {
-            return OverdueType.SOON_OVERDUE;
-        }
-        return OverdueType.NONE;
-    }
+	/**
+	 * 연체 타입을 반환하는 메소드 연체 예정인 경우, SOON_OVERDUE를 반환하고, 연체 기간이 지난 경우, OVERDUE를 반환한다. 그 외의 경우, NONE을
+	 * 반환한다.
+	 *
+	 * @param isExpired              연체 기간이 지났는지 여부 (true: 연체 기간이 지남, false: 연체 기간이 지나지 않음)
+	 * @param daysLeftFromExpireDate 만료일까지 남은 일수
+	 * @return 연체 타입
+	 */
+	public OverdueType getOverdueType(Boolean isExpired, Long daysLeftFromExpireDate) {
+		log.info("called getOverdueType with {}, {}", isExpired, daysLeftFromExpireDate);
+		if (isExpired) {
+			return OverdueType.OVERDUE;
+		}
 
-    public void handleOverdue(ActiveLentHistoryDto activeLent) {
-        log.info("called handleOverdue with {}", activeLent);
-        OverdueType overdueType = getOverdueType(activeLent.getIsExpired(),
-                activeLent.getDaysLeftFromExpireDate());
-        log.info("overdueType = {}", overdueType);
-        switch (overdueType) {
-            case NONE:
-                return;
-            case SOON_OVERDUE:
-                eventPublisher.publishEvent(AlarmEvent.of(activeLent.getUserId(),
-                        new LentExpirationImminentAlarm(activeLent.getDaysLeftFromExpireDate())));
-                break;
-            case OVERDUE:
-                cabinetFacadeService.updateStatus(activeLent.getCabinetId(),
-                        CabinetStatus.OVERDUE);
-                eventPublisher.publishEvent(AlarmEvent.of(activeLent.getUserId(),
-                        new LentExpirationAlarm(activeLent.getDaysLeftFromExpireDate())));
-                break;
-        }
-    }
+		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermWeekAge())) {
+			return OverdueType.SOON_OVERDUE;
+		}
+		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermThreeDaysAgo())) {
+			return OverdueType.SOON_OVERDUE;
+		}
+		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermSoonOverdue())) {
+			return OverdueType.SOON_OVERDUE;
+		}
+		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermOverdue())) {
+			return OverdueType.OVERDUE;
+		}
+		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermThreeDaysOverdue())) {
+			return OverdueType.OVERDUE;
+		}
+		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermWeekOverdue())) {
+			return OverdueType.OVERDUE;
+		}
+		return OverdueType.NONE;
+	}
+
+	public void handleOverdue(ActiveLentHistoryDto activeLent) {
+		log.info("called handleOverdue with {}", activeLent);
+		OverdueType overdueType = getOverdueType(activeLent.getIsExpired(),
+				activeLent.getDaysLeftFromExpireDate());
+		log.info("overdueType = {}", overdueType);
+		switch (overdueType) {
+			case NONE:
+				return;
+			case SOON_OVERDUE:
+				eventPublisher.publishEvent(AlarmEvent.of(activeLent.getUserId(),
+						new LentExpirationImminentAlarm(activeLent.getDaysLeftFromExpireDate())));
+				break;
+			case OVERDUE:
+				cabinetFacadeService.updateStatus(activeLent.getCabinetId(),
+						CabinetStatus.OVERDUE);
+				eventPublisher.publishEvent(AlarmEvent.of(activeLent.getUserId(),
+						new LentExpirationAlarm(activeLent.getDaysLeftFromExpireDate())));
+				break;
+		}
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/utils/overdue/manager/OverdueManager.java
+++ b/backend/src/main/java/org/ftclub/cabinet/utils/overdue/manager/OverdueManager.java
@@ -51,13 +51,7 @@ public class OverdueManager {
 		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermSoonOverdue())) {
 			return OverdueType.SOON_OVERDUE;
 		}
-		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermOverdue())) {
-			return OverdueType.OVERDUE;
-		}
-		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermThreeDaysOverdue())) {
-			return OverdueType.OVERDUE;
-		}
-		if (daysLeftFromExpireDate.equals(alarmProperties.getOverdueTermWeekOverdue())) {
+		if (daysLeftFromExpireDate >= alarmProperties.getOverdueTermOverdue()) {
 			return OverdueType.OVERDUE;
 		}
 		return OverdueType.NONE;

--- a/backend/src/main/java/org/ftclub/cabinet/utils/overdue/manager/OverdueType.java
+++ b/backend/src/main/java/org/ftclub/cabinet/utils/overdue/manager/OverdueType.java
@@ -1,6 +1,7 @@
 package org.ftclub.cabinet.utils.overdue.manager;
 
 public enum OverdueType {
+
 	SOON_OVERDUE,
 	OVERDUE,
 	NONE

--- a/backend/src/main/java/org/ftclub/cabinet/utils/scheduler/SystemScheduler.java
+++ b/backend/src/main/java/org/ftclub/cabinet/utils/scheduler/SystemScheduler.java
@@ -1,24 +1,21 @@
 package org.ftclub.cabinet.utils.scheduler;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.ftclub.cabinet.dto.ActiveLentHistoryDto;
 import org.ftclub.cabinet.dto.UserBlackHoleEvent;
 import org.ftclub.cabinet.lent.service.LentFacadeService;
-import org.ftclub.cabinet.occupiedtime.OccupiedTimeManager;
 import org.ftclub.cabinet.user.service.LentExtensionManager;
 import org.ftclub.cabinet.user.service.UserQueryService;
 import org.ftclub.cabinet.utils.blackhole.manager.BlackholeManager;
-import org.ftclub.cabinet.utils.leave.absence.LeaveAbsenceManager;
 import org.ftclub.cabinet.utils.overdue.manager.OverdueManager;
 import org.ftclub.cabinet.utils.release.ReleaseManager;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * 시스템 스케줄러
@@ -29,25 +26,23 @@ import java.util.stream.Collectors;
 @Log4j2
 public class SystemScheduler {
 
-    private static final long DELAY_TIME = 2000;
-    private final UserQueryService userQueryService;
-    private final LeaveAbsenceManager leaveAbsenceManager;
-    private final LentExtensionManager lentExtensionManager;
-    private final OverdueManager overdueManager;
-    private final LentFacadeService lentFacadeService;
-    private final BlackholeManager blackholeManager;
-    private final ReleaseManager releaseManager;
-    private final OccupiedTimeManager occupiedTimeManager;
+	private static final long DELAY_TIME = 2000;
+	private final UserQueryService userQueryService;
+	private final LentExtensionManager lentExtensionManager;
+	private final OverdueManager overdueManager;
+	private final LentFacadeService lentFacadeService;
+	private final BlackholeManager blackholeManager;
+	private final ReleaseManager releaseManager;
 
-    /**
-     * 매일 자정마다 대여 기록을 확인하여, 연체 메일 발송 및 휴학생 처리를 트리거하는 메소드 2초 간격으로 블랙홀 검증
-     */
-    @Scheduled(cron = "${cabinet.schedule.cron.leave-absence}")
-    public void checkAllLents() {
-        log.info("called checkAllLents");
-        List<ActiveLentHistoryDto> activeLents = lentFacadeService.getAllActiveLentHistories();
-        for (ActiveLentHistoryDto activeLent : activeLents) {
-            overdueManager.handleOverdue(activeLent);
+	/**
+	 * 매일 자정마다 대여 기록을 확인하여, 연체 메일 발송 및 휴학생 처리를 트리거
+	 */
+	@Scheduled(cron = "${cabinet.schedule.cron.leave-absence}")
+	public void checkAllLents() {
+		log.info("called checkAllLents");
+		List<ActiveLentHistoryDto> activeLents = lentFacadeService.getAllActiveLentHistories();
+		for (ActiveLentHistoryDto activeLent : activeLents) {
+			overdueManager.handleOverdue(activeLent);
 /*
             leaveAbsenceManager.handleLeaveAbsence(activeLent.getUserId(), activeLent.getName());
             try {
@@ -56,66 +51,69 @@ public class SystemScheduler {
                 log.error(e.getMessage());
             }
 */
-        }
-    }
+		}
+	}
 
-    /**
-     * 매주 월요일 자정 42분에 블랙홀에 빠진 유저 처리를 트리거하는 메소드 2초 간격으로 블랙홀 검증
-     */
-    @Scheduled(cron = "${cabinet.schedule.cron.risk-of-blackhole}")
-    public void checkRiskOfBlackhole() {
-        log.info("called checkRiskOfBlackhole");
+	/**
+	 * 매주 월요일 자정 42분에 블랙홀에 빠진 유저 처리를 트리거하는 메소드 2초 간격으로 블랙홀 검증
+	 */
+	@Scheduled(cron = "${cabinet.schedule.cron.risk-of-blackhole}")
+	public void checkRiskOfBlackhole() {
+		log.info("called checkRiskOfBlackhole");
 
-        List<UserBlackHoleEvent> closeWithBlackholeUsers = userQueryService.findUsersAtRiskOfBlackhole().stream()
-                .map(user -> UserBlackHoleEvent.of(user.getId(), user.getName(), user.getEmail(), user.getBlackholedAt()))
-                .collect(Collectors.toList());
-        for (UserBlackHoleEvent blackholeInfo : closeWithBlackholeUsers) {
-            blackholeManager.handleBlackHole(blackholeInfo);
-            try {
-                Thread.sleep(DELAY_TIME);
-            } catch (InterruptedException e) {
-                log.error(e.getMessage());
-            }
-        }
-    }
+		List<UserBlackHoleEvent> closeWithBlackholeUsers = userQueryService.findUsersAtRiskOfBlackhole()
+				.stream()
+				.map(user -> UserBlackHoleEvent.of(user.getId(), user.getName(), user.getEmail(),
+						user.getBlackholedAt()))
+				.collect(Collectors.toList());
+		for (UserBlackHoleEvent blackholeInfo : closeWithBlackholeUsers) {
+			blackholeManager.handleBlackHole(blackholeInfo);
+			try {
+				Thread.sleep(DELAY_TIME);
+			} catch (InterruptedException e) {
+				log.error(e.getMessage());
+			}
+		}
+	}
 
-    /**
-     * 매월 1일 01시 42분에 블랙홀에 빠질 위험이 없는 유저들의 블랙홀 처리를 트리거하는 메소드 2초 간격으로 블랙홀 검증
-     */
-    @Scheduled(cron = "${cabinet.schedule.cron.no-risk-of-blackhole}")
-    public void checkNoRiskOfBlackhole() {
-        log.info("called checkNoRiskOfBlackhole");
+	/**
+	 * 매월 1일 01시 42분에 블랙홀에 빠질 위험이 없는 유저들의 블랙홀 처리를 트리거하는 메소드 2초 간격으로 블랙홀 검증
+	 */
+	@Scheduled(cron = "${cabinet.schedule.cron.no-risk-of-blackhole}")
+	public void checkNoRiskOfBlackhole() {
+		log.info("called checkNoRiskOfBlackhole");
 
-        List<UserBlackHoleEvent> safeFromBlackholeUsers = userQueryService.findUsersAtNoRiskOfBlackhole()
-                .stream()
-                .map(user -> UserBlackHoleEvent.of(user.getId(), user.getName(), user.getEmail(), user.getBlackholedAt()))
-                .collect(Collectors.toList());
+		List<UserBlackHoleEvent> safeFromBlackholeUsers = userQueryService.findUsersAtNoRiskOfBlackhole()
+				.stream()
+				.map(user -> UserBlackHoleEvent.of(user.getId(), user.getName(), user.getEmail(),
+						user.getBlackholedAt()))
+				.collect(Collectors.toList());
 
-        for (UserBlackHoleEvent blackholeUserInfo : safeFromBlackholeUsers) {
-            blackholeManager.handleBlackHole(blackholeUserInfo);
-            try {
-                Thread.sleep(DELAY_TIME);
-            } catch (InterruptedException e) {
-                log.error(e.getMessage());
-            }
-        }
-    }
+		for (UserBlackHoleEvent blackholeUserInfo : safeFromBlackholeUsers) {
+			blackholeManager.handleBlackHole(blackholeUserInfo);
+			try {
+				Thread.sleep(DELAY_TIME);
+			} catch (InterruptedException e) {
+				log.error(e.getMessage());
+			}
+		}
+	}
 
-    /**
-     * 매월 1일 01시 42분에 블랙홀에 빠질 위험이 없는 유저들의 블랙홀 처리를 트리거하는 메소드 2초 간격으로 블랙홀 검증
-     */
-    //현재 5분마다 도는 로직  0 */5 * * * *
-    @Scheduled(cron = "${cabinet.schedule.cron.cabinet-release-time}")
-    public void releasePendingCabinet() {
-        log.info("releasePendingCabinet {}", LocalDateTime.now());
-        releaseManager.releasingCabinets();
-    }
+	/**
+	 * 매월 1일 01시 42분에 블랙홀에 빠질 위험이 없는 유저들의 블랙홀 처리를 트리거하는 메소드 2초 간격으로 블랙홀 검증
+	 */
+	//현재 5분마다 도는 로직  0 */5 * * * *
+	@Scheduled(cron = "${cabinet.schedule.cron.cabinet-release-time}")
+	public void releasePendingCabinet() {
+		log.info("releasePendingCabinet {}", LocalDateTime.now());
+		releaseManager.releasingCabinets();
+	}
 
-    @Scheduled(cron = "${cabinet.schedule.cron.extension-issue-time}")
-    public void lentExtensionIssue() {
-        log.info("called lentExtensionIssue");
-        lentExtensionManager.issueLentExtension();
-    }
+	@Scheduled(cron = "${cabinet.schedule.cron.extension-issue-time}")
+	public void lentExtensionIssue() {
+		log.info("called lentExtensionIssue");
+		lentExtensionManager.issueLentExtension();
+	}
 
 //	@Scheduled(cron = "${cabinet.schedule.cron.extensible-user-check}")
 //	public void checkUserQualifyForExtensible(){


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1518

연체 전후 1, 3, 7일차에도 알람을 보내도록 기능 변경