### PR TITLE
[FE] FEAT: 구글 애널리틱스 고도화 #1565

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,20 +1,6 @@
 <!DOCTYPE html>
 <html lang="ko">
   <head>
-    <!-- Google tag (gtag.js) -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-Q41WN2559Z"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-
-      gtag("config", "G-Q41WN2559Z");
-    </script>
     <meta charset="UTF-8" />
     <link rel="icon" href="/src/assets/images/logo.ico" type="image/x-icon" />
     <link rel="shortcut icon" href="/src/assets/images/logo.png" />

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "react-color": "^2.19.3",
         "react-cookie": "^4.1.1",
         "react-dom": "^18.2.0",
-        "react-ga": "^3.3.1",
+        "react-ga4": "^2.1.0",
         "react-router-dom": "^6.5.0",
         "recoil": "^0.7.6",
         "recoil-persist": "^4.2.0",
@@ -9223,14 +9223,10 @@
         "react": "^18.2.0"
       }
     },
-    "node_modules/react-ga": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
-      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
-      "peerDependencies": {
-        "prop-types": "^15.6.0",
-        "react": "^15.6.2 || ^16.0 || ^17 || ^18"
-      }
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "node_modules/react-is": {
       "version": "18.2.0",
@@ -17588,11 +17584,10 @@
         "scheduler": "^0.23.0"
       }
     },
-    "react-ga": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-3.3.1.tgz",
-      "integrity": "sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==",
-      "requires": {}
+    "react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "react-is": {
       "version": "18.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "react-color": "^2.19.3",
     "react-cookie": "^4.1.1",
     "react-dom": "^18.2.0",
-    "react-ga": "^3.3.1",
+    "react-ga4": "^2.1.0",
     "react-router-dom": "^6.5.0",
     "recoil": "^0.7.6",
     "recoil-persist": "^4.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
+import TrackPageView from "@/TrackPageView";
 import React, { Suspense, lazy } from "react";
+import ReactGA from "react-ga4";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import AvailablePage from "@/pages/AvailablePage";
 import ClubPage from "@/pages/ClubPage";
@@ -26,6 +28,8 @@ const AdminHomePage = lazy(() => import("@/pages/admin/AdminHomePage"));
 function App(): React.ReactElement {
   return (
     <BrowserRouter>
+      {/* GA4 Page Traking */}
+      <TrackPageView />
       <Suspense fallback={<LoadingAnimation />}>
         <Routes>
           <Route path="/post-login" element={<PostLogin />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,4 @@
-import TrackPageView from "@/TrackPageView";
 import React, { Suspense, lazy } from "react";
-import ReactGA from "react-ga4";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import AvailablePage from "@/pages/AvailablePage";
 import ClubPage from "@/pages/ClubPage";
@@ -13,6 +11,7 @@ import PostLogin from "@/pages/PostLogin";
 import ProfilePage from "@/pages/ProfilePage";
 import AdminMainPage from "@/pages/admin/AdminMainPage";
 import LoadingAnimation from "@/components/Common/LoadingAnimation";
+import PageTracker from "@/api/analytics/PageTracker";
 
 const NotFoundPage = lazy(() => import("@/pages/NotFoundPage"));
 const LoginFailurePage = lazy(() => import("@/pages/LoginFailurePage"));
@@ -28,8 +27,8 @@ const AdminHomePage = lazy(() => import("@/pages/admin/AdminHomePage"));
 function App(): React.ReactElement {
   return (
     <BrowserRouter>
-      {/* GA4 Page Traking */}
-      <TrackPageView />
+      {/* GA4 Page Tracking Component */}
+      <PageTracker />
       <Suspense fallback={<LoadingAnimation />}>
         <Routes>
           <Route path="/post-login" element={<PostLogin />} />

--- a/frontend/src/TrackPageView.tsx
+++ b/frontend/src/TrackPageView.tsx
@@ -10,7 +10,7 @@ const TrackPageView = () => {
     if (
       !initialized &&
       import.meta.env.VITE_GA_TRACKING_ID &&
-      window.location.hostname.includes("localhost")
+      !window.location.hostname.includes("localhost")
     ) {
       ReactGA.initialize(`${import.meta.env.VITE_GA_TRACKING_ID}`);
       setInitialized(true);

--- a/frontend/src/TrackPageView.tsx
+++ b/frontend/src/TrackPageView.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import ReactGA from "react-ga4";
+import { useLocation } from "react-router-dom";
+
+const TrackPageView = () => {
+  const location = useLocation();
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (
+      !initialized &&
+      import.meta.env.VITE_GA_TRACKING_ID &&
+      window.location.hostname.includes("localhost")
+    ) {
+      ReactGA.initialize(`${import.meta.env.VITE_GA_TRACKING_ID}`);
+      setInitialized(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!initialized) return;
+    ReactGA.send({
+      hitType: "pageview",
+      page: location.pathname,
+      title: location.pathname,
+    });
+  }, [initialized, location]);
+
+  return null;
+};
+
+export default TrackPageView;

--- a/frontend/src/api/analytics/PageTracker.tsx
+++ b/frontend/src/api/analytics/PageTracker.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import ReactGA from "react-ga4";
 import { useLocation } from "react-router-dom";
 
-const TrackPageView = () => {
+const PageTracker = () => {
   const location = useLocation();
   const [initialized, setInitialized] = useState(false);
 
@@ -29,4 +29,4 @@ const TrackPageView = () => {
   return null;
 };
 
-export default TrackPageView;
+export default PageTracker;

--- a/frontend/src/components/Card/NotificationCard/NotificationCard.container.tsx
+++ b/frontend/src/components/Card/NotificationCard/NotificationCard.container.tsx
@@ -3,7 +3,6 @@ import {
   requestFcmAndGetDeviceToken,
 } from "@/firebase/firebase-messaging-sw";
 import { useEffect, useMemo, useState } from "react";
-import { set } from "react-ga";
 import NotificationCard from "@/components/Card/NotificationCard/NotificationCard";
 import ModalPortal from "@/components/Modals/ModalPortal";
 import {

--- a/frontend/src/components/Search/SearchItemByIntraId.tsx
+++ b/frontend/src/components/Search/SearchItemByIntraId.tsx
@@ -1,4 +1,3 @@
-import { set } from "react-ga";
 import { useRecoilState, useResetRecoilState, useSetRecoilState } from "recoil";
 import styled, { css } from "styled-components";
 import {

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { set } from "react-ga";
 import { Outlet } from "react-router";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSetRecoilState } from "recoil";


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
> Closed #1565 

### GA main, dev, local 환경 구분
이전 방식으로는 Index.html에 script를 직접 적용해서 구글 애널리틱스에 추적이 되었습니다.
main만 추적이 되도록 메인 index.html에만 적용해뒀었는데, 버전관리를 진행하면서 로컬,dev에도 적용이 되어서 main만 구분이 안되었습니다.
사실 현재 적용되어 있는 것들은 main,dev,local 모든 이벤트를 추적하고 있는 상태였습니다.

이번 수정으로  .env에 VITE_GA_TRACKING_ID를 통해서 추적되도록 변경했습니다.
이전에 사용중인 GA-ID로는 main만 추적되도록 적용했으며, 
테스트용으로 만든 다른 GA-ID는 dev에 연결되도록 dev.env와 .env에 추가했습니다. 
로컬 작업중에는 추적하지 않도록 조건문을 추가해서 막았습니다.
```js
!window.location.hostname.includes("localhost")
```

### 경로 구분
react-ga4를 사용했으며, path(라우터)가 변경될때마다 이벤트를 추적하도록 변경했습니다.

- 예시
<img width="387" alt="image" src="https://github.com/innovationacademy-kr/Cabi/assets/72684256/8fa4bba4-9849-4098-b5e6-383139d7ce0f">

### Tracking 컴포넌트
GA를 위한 파일을 구분화 했습니다.
PageTracker로 컴포넌트화 한 이유는 처음에는 custom Hook으로 빼려고 했으나,
 useLocation를 사용은 Router 내에서만 사용할 수 있어서 App.tsx에 자체에서 실행하려고 하면 오류가 납니다.
그렇기 때문에 따로 컴포넌트로 만들어서 routers 내부에 적용하는 방식으로 처리했습니다.

### 기타
컴포넌트 형태이지만 실제 역할은 view를 그리기 위함이 아닌 페이지, 이벤트 추적을 위한 코드가 들어 있어서, 파일을 api/analytics/PageTracker 위치에 두었습니다.
