### PR TITLE
[FE] FIX: CabinetInfoArea 에서 뒤로가기 모달이 정상적으로 닫히지 않던 문제 수정 #1567

### DIFF
--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import {
   myCabinetInfoState,
@@ -64,6 +65,31 @@ export interface IAdminCurrentModalStateInfo {
   statusModal: boolean;
   clubLentModal: boolean;
 }
+
+/**
+ * @description 모달 상태 (interface) 를 받아 기본값 (false) 으로 초기화
+ *
+ * @param modalStateInfo 모달 상태 (interface)
+ *
+ * @returns 모달 상태 (interface) 의 각 속성을 false 로 초기화한 객체
+ *
+ * @example
+ * const defaultModalStateInfo: ICurrentModalStateInfo = initializeDefaultModalState({} as ICurrentModalStateInfo);
+ * //=> { lentModal: false, unavailableModal: false, returnModal: false, memoModal: false, passwordCheckModal: false, invitationCodeModal: false, extendModal: false, cancelModal: false, swapModal: false }
+ */
+const initializeDefaultModalState = <T extends Object>(modalStateInfo: T): T =>
+  Object.freeze(
+    Object.entries(modalStateInfo).reduce(
+      (acc, [key]) => ({ ...acc, [key]: false }),
+      {} as T
+    )
+  );
+
+const defaultModalStateInfo: ICurrentModalStateInfo =
+  initializeDefaultModalState({} as ICurrentModalStateInfo);
+
+const defaultAdminModalStateInfo: IAdminCurrentModalStateInfo =
+  initializeDefaultModalState({} as IAdminCurrentModalStateInfo);
 
 interface ICount {
   AVAILABLE: number;
@@ -161,26 +187,17 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
   const myCabinetInfo =
     useRecoilValue<MyCabinetInfoResponseDto>(myCabinetInfoState);
   const myInfo = useRecoilValue<UserDto>(userState);
+  const isAdmin = document.location.pathname.indexOf("/admin") > -1;
+  const [userModal, setUserModal] = useState<ICurrentModalStateInfo>(
+    defaultModalStateInfo
+  );
+  const [adminModal, setAdminModal] = useState<IAdminCurrentModalStateInfo>(
+    defaultAdminModalStateInfo
+  );
   const { isMultiSelect, targetCabinetInfoList } = useMultiSelect();
   const { closeCabinet, toggleLent } = useMenu();
   const { isSameStatus, isSameType } = useMultiSelect();
-  const isAdmin = document.location.pathname.indexOf("/admin") > -1;
-  const [userModal, setUserModal] = useState<ICurrentModalStateInfo>({
-    lentModal: false,
-    unavailableModal: false,
-    returnModal: false,
-    memoModal: false,
-    passwordCheckModal: false,
-    invitationCodeModal: false,
-    extendModal: false,
-    cancelModal: false,
-    swapModal: false,
-  });
-  const [adminModal, setAdminModal] = useState<IAdminCurrentModalStateInfo>({
-    returnModal: false,
-    statusModal: false,
-    clubLentModal: false,
-  });
+  const location = useLocation();
 
   const cabinetViewData: ISelectedCabinetInfo | null = targetCabinetInfo
     ? {
@@ -295,6 +312,11 @@ const CabinetInfoAreaContainer = (): JSX.Element => {
       return true;
     return false;
   };
+
+  useEffect(() => {
+    setUserModal(defaultModalStateInfo);
+    setAdminModal(defaultAdminModalStateInfo);
+  }, [location]);
 
   return isAdmin ? (
     <>


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

- CabientInfoArea 에서 해당 컴포넌트를 이용해 모달 (사물함 관리, 대여, 반납 등) 을 열고, 브라우저 뒤로가기를 눌렀을 시 모달이 정상적으로 닫히지 않아 다른 사물함을 클릭했을 시 마지막으로 열었던 모달이 그대로 랜더링되는 이슈가 있어 이를 useLocation() 을 사용해 URL 변경 시 모달 값을 초기화하도록 변경했습니다
- 모달 값을 초기화 할 시 { lentModal: false, unavailableModal: false ... } 등으로 나열하는 것이 효율적이지 않다고 판단하여 ICurrentModalStateInfo 와 IAdminCurrentModalStateInfo interface 를 초기화해 Object 를 반환하는 함수를 만들고 이를 사용하도록 변경하였습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1567
