### PR TITLE
[FE] FIX: 동아리 사물함이 비었을 때 반납이 출력되는 이슈 수정 #1574

### DIFF
--- a/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
+++ b/frontend/src/components/CabinetInfoArea/CabinetInfoArea.container.tsx
@@ -134,8 +134,9 @@ const getCalcualtedTimeString = (expireTime: Date) => {
 
 const getCabinetUserList = (selectedCabinetInfo: CabinetInfo): string => {
   // 동아리 사물함인 경우 cabinet_title에 있는 동아리 이름 반환
-  const { lentType, title, maxUser, lents } = selectedCabinetInfo;
-  if (lentType === "CLUB" && title) return title;
+  const { lentType, title, maxUser, lents, status } = selectedCabinetInfo;
+  if (lentType === "CLUB" && title && status == CabinetStatus.FULL)
+    return title;
   else if (maxUser === 0) return "";
 
   // 그 외에는 유저리스트 반환


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

- 문제: 동아리 사물함 페이지가 구현 및 적용 된 이후에 반납 시 사물함 title (동아리 명) 이 초기화되나, 이전에 할당한 동아리 사물함 (42cabi, 관리용 등) 은 title 이 초기화되지 않아 Status 가 AVAILABLE 임에도 '동아리 대여' 대신 '반납' 버튼이 출력됨.
- 하위 호환성을 위해 대여 판별식에 Status 도 확인하도록 수정

https://github.com/innovationacademy-kr/42cabi/issues/1574
