### PR TITLE
[FE] FIX: 내 사물함 버튼 클릭 시 버튼이 깜빡이는 문제 수정 #1576

### DIFF
--- a/frontend/src/components/TopNav/TopNav.tsx
+++ b/frontend/src/components/TopNav/TopNav.tsx
@@ -30,7 +30,7 @@ const BuildingListItem: React.FC<IBuildingListItem> = ({
   );
 };
 
-const TopNav: React.FC<{
+interface ITopNav {
   currentBuildingName: string;
   buildingsList: Array<string>;
   buildingClicked: boolean;
@@ -38,17 +38,17 @@ const TopNav: React.FC<{
   onClickLogo: React.MouseEventHandler<SVGSVGElement>;
   setCurrentBuildingName: SetterOrUpdater<string>;
   isAdmin?: boolean;
-}> = (props) => {
-  const {
-    currentBuildingName,
-    buildingsList,
-    buildingClicked,
-    setBuildingClicked,
-    onClickLogo,
-    setCurrentBuildingName,
-    isAdmin,
-  } = props;
+}
 
+const TopNav = ({
+  currentBuildingName,
+  buildingsList,
+  buildingClicked,
+  setBuildingClicked,
+  onClickLogo,
+  setCurrentBuildingName,
+  isAdmin = false,
+}: ITopNav) => {
   const buildingDom = React.useRef<HTMLElement>(null);
   useOutsideClick(buildingDom, () => {
     if (buildingClicked) setBuildingClicked(false);

--- a/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButton/TopNavButton.tsx
+++ b/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButton/TopNavButton.tsx
@@ -34,7 +34,8 @@ const TopNavButtonStyled = styled.div<{
   height: 32px;
   margin-right: 10px;
   cursor: pointer;
-  display: ${({ disable }) => (disable ? "none" : "block")};
+  /* display: ${({ disable }) => (disable ? "none" : "block")}; */
+  /* visibility: ${({ disable }) => (disable ? "hidden" : "visible")}; */
   @media (hover: hover) and (pointer: fine) {
     &:hover {
       opacity: 0.9;

--- a/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
+++ b/frontend/src/components/TopNav/TopNavButtonGroup/TopNavButtonGroup.tsx
@@ -47,7 +47,6 @@ const TopNavButtonGroup = ({ isAdmin }: { isAdmin?: boolean }) => {
 
   async function setTargetCabinetInfoToMyCabinet() {
     setCurrentCabinetId(myInfo.cabinetId);
-    setMyInfo((prev) => ({ ...prev, cabinetId: null }));
     try {
       if (!myCabinetInfo?.cabinetId) return;
       const { data } = await axiosCabinetById(myCabinetInfo.cabinetId);
@@ -109,7 +108,7 @@ const TopNavButtonGroup = ({ isAdmin }: { isAdmin?: boolean }) => {
           disable={true}
         />
       )}
-      {!isAdmin && (
+      {!isAdmin && !!myInfo.cabinetId && (
         <TopNavButton
           disable={!myInfo.cabinetId}
           onClick={clickMyCabinet}


### PR DESCRIPTION
## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

내 사물함 버튼을 클릭 시, 우측 CabinetInfoArea 에 표시할 케비넷을 '나의 케비넷' 으로 변경하는데, 이때:
```
setMyInfo((prev) => ({ ...prev, cabinetId: null }))
```
  recoil state 인 myInfo 를 항상 업데이트 하고 있었기 때문에 렌더링이 두번 발생하면서 깜빡이는 것 처럼 보이는 현상을 필요할 때만 myInfo 를 업데이트하도록 변경했습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1576
