### PR TITLE
[BE] BUG: AllRequestLogInterceptor NPE 수정 #1583

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/log/AllRequestLogInterceptor.java
+++ b/backend/src/main/java/org/ftclub/cabinet/log/AllRequestLogInterceptor.java
@@ -78,7 +78,7 @@ public class AllRequestLogInterceptor implements HandlerInterceptor {
 			throw ExceptionStatus.JSON_PROCESSING_EXCEPTION.asControllerException();
 		}
 
-		if (payloadJson == null || isValidPayLoadName(payloadJson)) {
+		if (payloadJson == null || !isValidPayLoadName(payloadJson)) {
 			String uuid = UUID.randomUUID().toString();
 			return uuid.substring(uuid.length() - 12);
 		}
@@ -92,6 +92,6 @@ public class AllRequestLogInterceptor implements HandlerInterceptor {
 		if (payloadJson.get(PAYLOAD_NAME) == null) {
 			return false;
 		}
-		return payloadJson.get(PAYLOAD_NAME).asText().isEmpty();
+		return !payloadJson.get(PAYLOAD_NAME).asText().isEmpty();
 	}
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1583

AllRequestLogInterceptor NPE가 발생하는 버그 수정했습니다.
버그 원인은 `payloadJson`의 유효성 검증 로직의 오류였습니다.
AllRequestLogInterceptor에서 tokenValidator를 통해 token의 payload 정보(payloadJson)를 JSON 형식으로 받아오는데,
이때 payloadJson가 빈 문자열이거나, name 정보가 존재하지 않으면 NPE가 발생합니다.
이 버그를 재현하려면 브라우저 쿠키에 access_token 필드에 JWT 형식은 맞으나 payload에 name 정보가 없는 토큰을 넣고 요청해야 하기 때문에 프러덕션에서 발생할 확률은 매우 낮습니다만, 그래도 버그 수정하고 잘 동작하는 것까지 확인했습니다.
