### PR TITLE
[BE] FIX: 글로벌 에러 핸들링 개선 & 필요한 오류 알림만 상세화하여 보내도록 수정 #1593

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/alarm/discord/DiscordWebAlarmMessage.java
+++ b/backend/src/main/java/org/ftclub/cabinet/alarm/discord/DiscordWebAlarmMessage.java
@@ -1,0 +1,104 @@
+package org.ftclub.cabinet.alarm.discord;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Builder
+@Getter
+public class DiscordWebAlarmMessage {
+
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(
+			"yyyy-MM-dd HH:mm:ss");
+	private final String subject;
+	private final String requestURI;
+	private final String httpMethod;
+	private final String headers;
+	private final String body;
+	private final String parameters;
+	private final String responseBody;
+
+	public static DiscordWebAlarmMessage fromHttpServletRequest(HttpServletRequest request,
+			String subject,
+			String responseBody) {
+		String requestBody = "";
+		if (request instanceof ContentCachingRequestWrapper) {
+			byte[] buf = ((ContentCachingRequestWrapper) request).getContentAsByteArray();
+			requestBody = new String(buf, 0, buf.length, StandardCharsets.UTF_8).trim();
+		}
+
+		String headers = Collections.list(request.getHeaderNames())
+				.stream()
+				.collect(Collectors.toMap(h -> h, request::getHeader))
+				.entrySet()
+				.stream()
+				.map(entry -> "\"" + entry.getKey() + "\":\"" + entry.getValue() + "\"")
+				.collect(Collectors.joining(", ", "{", "}"));
+
+		String params = request.getParameterMap().entrySet()
+				.stream()
+				.map(entry -> "\"" + entry.getKey() + "\":\"" + Arrays.toString(entry.getValue())
+						+ "\"")
+				.collect(Collectors.joining(", ", "{", "}"));
+
+		return DiscordWebAlarmMessage.builder()
+				.subject(subject)
+				.requestURI(request.getRequestURI())
+				.httpMethod(request.getMethod())
+				.headers(headers)
+				.body(requestBody)
+				.parameters(params)
+				.responseBody(responseBody)
+				.build();
+	}
+
+	public static DiscordWebAlarmMessage fromWebRequest(WebRequest request, String subject,
+			String responseBody) {
+		if (request instanceof ServletWebRequest) {
+			HttpServletRequest servletRequest = ((ServletWebRequest) request).getRequest();
+			return fromHttpServletRequest(servletRequest, subject, responseBody);
+		} else {
+			String params = request.getParameterMap().entrySet().stream()
+					.map(entry -> entry.getKey() + "=" + String.join(", ", entry.getValue()))
+					.reduce((p1, p2) -> p1 + "; " + p2)
+					.orElse("No parameters");
+
+			String method = request.getHeader("X-HTTP-Method-Override"); // 클라이언트가 메서드를 오버라이드 했을 경우
+			if (method == null) {
+				method = request.getHeader("Method");
+			}
+
+			return DiscordWebAlarmMessage.builder()
+					.subject(subject)
+					.requestURI(request.getContextPath())
+					.httpMethod(method)
+					.parameters(params)
+					.responseBody(responseBody)
+					.build();
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "```java\n" +
+				"Subject: \"" + subject + "\"\n" +
+				"Issued at: \"" + LocalDateTime.now().format(formatter) + "\"\n" +
+				"Request URI: \"" + requestURI + "\"\n" +
+				"HTTP Method: \"" + httpMethod + "\"\n" +
+				"Request Headers: \"" + headers + "\"\n" +
+				"Request Body: \"" + body + "\"\n" +
+				"Request Parameters: \"" + parameters + "\"\n" +
+				"Response Body: \"" + responseBody + "\"\n" +
+				"```";
+	}
+}

--- a/backend/src/main/java/org/ftclub/cabinet/alarm/discord/DiscordWebHookMessenger.java
+++ b/backend/src/main/java/org/ftclub/cabinet/alarm/discord/DiscordWebHookMessenger.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 @Component
 public class DiscordWebHookMessenger {
+
 	private final static String DISCORD_WEBHOOK_MESSAGE_KEY = "content";
 	private final String discordWebHookUrl;
 
@@ -17,6 +18,18 @@ public class DiscordWebHookMessenger {
 	}
 
 	public void sendMessage(DiscordAlarmMessage message) {
+		Map<String, String> body = new HashMap<>();
+		body.put(DISCORD_WEBHOOK_MESSAGE_KEY, message.toString());
+
+		WebClient.create().post()
+				.uri(discordWebHookUrl)
+				.bodyValue(body)
+				.retrieve()
+				.bodyToMono(String.class)
+				.block();
+	}
+
+	public void sendMessage(DiscordWebAlarmMessage message) {
 		Map<String, String> body = new HashMap<>();
 		body.put(DISCORD_WEBHOOK_MESSAGE_KEY, message.toString());
 

--- a/backend/src/main/java/org/ftclub/cabinet/auth/filter/CachingRequestBodyFilter.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/filter/CachingRequestBodyFilter.java
@@ -1,0 +1,22 @@
+package org.ftclub.cabinet.auth.filter;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+public class CachingRequestBodyFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+			FilterChain filterChain)
+			throws ServletException, IOException {
+		HttpServletRequest wrappedRequest = new ContentCachingRequestWrapper(request);
+		filterChain.doFilter(wrappedRequest, response);
+	}
+}

--- a/backend/src/main/java/org/ftclub/cabinet/auth/service/AdminOauthService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/service/AdminOauthService.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutionException;
 @Log4j2
 @RequiredArgsConstructor
 public class AdminOauthService {
+
 	@Qualifier(OauthConfig.GOOGLE_OAUTH_20_SERVICE)
 	private final OAuth20Service googleOAuth20Service;
 	private final ObjectMapper objectMapper;
@@ -46,21 +47,24 @@ public class AdminOauthService {
 	 * @throws ExecutionException   비동기 처리시 스레드에서 발생한 오류 처리 예외
 	 * @throws InterruptedException 비동기 처리시 스레드 종료를 위한 예외
 	 */
-	public GoogleProfile getProfileByCode(String code) throws IOException, ExecutionException, InterruptedException {
+	public GoogleProfile getProfileByCode(String code)
+			throws IOException, ExecutionException, InterruptedException {
 		OAuth2AccessToken accessToken = googleOAuth20Service.getAccessToken(code);
-		OAuthRequest oAuthRequest = new OAuthRequest(Verb.GET, "https://www.googleapis.com/oauth2/v2/userinfo");
+		OAuthRequest oAuthRequest = new OAuthRequest(Verb.GET,
+				"https://www.googleapis.com/oauth2/v2/userinfo");
 		googleOAuth20Service.signRequest(accessToken, oAuthRequest);
 		try {
 			Response response = googleOAuth20Service.execute(oAuthRequest);
 			return convertJsonStringToProfile(response.getBody());
 		} catch (Exception e) {
-			if (e instanceof IOException)
+			if (e instanceof IOException) {
 				log.error("42 API 서버에서 프로필 정보를 가져오는데 실패했습니다."
 						+ "code: {}, message: {}", code, e.getMessage());
-			if (e instanceof ExecutionException || e instanceof InterruptedException)
+			}
+			if (e instanceof ExecutionException || e instanceof InterruptedException) {
 				log.error("42 API 서버에서 프로필 정보를 비동기적으로 가져오는데 실패했습니다."
 						+ "code: {}, message: {}", code, e.getMessage());
-			e.printStackTrace();
+			}
 			throw ExceptionStatus.INTERNAL_SERVER_ERROR.asServiceException();
 		}
 	}
@@ -71,7 +75,8 @@ public class AdminOauthService {
 	 * @param jsonString
 	 * @return
 	 * @throws IOException
-	 * @see <a href="https://developers.google.com/identity/protocols/oauth2/openid-connect#obtainuserinfo">참고</a>
+	 * @see <a
+	 * href="https://developers.google.com/identity/protocols/oauth2/openid-connect#obtainuserinfo">참고</a>
 	 */
 	private GoogleProfile convertJsonStringToProfile(String jsonString) throws IOException {
 		JsonNode jsonNode = objectMapper.readTree(jsonString);

--- a/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionController.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionController.java
@@ -25,12 +25,9 @@ public class ExceptionController extends ResponseEntityExceptionHandler {
 
 	@ExceptionHandler(ControllerException.class)
 	public ResponseEntity<?> controllerExceptionHandler(ControllerException e) {
-		StackTraceElement stackTraceElement = e.getStackTrace()[0];
-		log.info("[ControllerException] {} : {} at {}",
-				e.status.getError(), e.status.getMessage(),
-				stackTraceElement);
+		log.info("[ControllerException] {} : {}", e.status.getError(), e.status.getMessage());
 		if (log.isDebugEnabled()) {
-			log.debug(e);
+			log.debug("Exception stack trace: ", e);
 		}
 		return ResponseEntity
 				.status(e.status.getStatusCode())
@@ -41,7 +38,7 @@ public class ExceptionController extends ResponseEntityExceptionHandler {
 	public ResponseEntity<?> serviceExceptionHandler(ServiceException e) {
 		log.info("[ServiceException] {} : {}", e.status.getError(), e.status.getMessage());
 		if (log.isDebugEnabled()) {
-			log.debug(e);
+			log.debug("Exception stack trace: ", e);
 		}
 		return ResponseEntity
 				.status(e.status.getStatusCode())
@@ -52,7 +49,7 @@ public class ExceptionController extends ResponseEntityExceptionHandler {
 	public ResponseEntity<?> customServiceExceptionHandler(CustomServiceException e) {
 		log.info("[CustomServiceException] {} : {}", e.status.getError(), e.status.getMessage());
 		if (log.isDebugEnabled()) {
-			log.debug(e);
+			log.debug("Exception stack trace: ", e);
 		}
 		return ResponseEntity
 				.status(e.status.getStatusCode())
@@ -63,7 +60,7 @@ public class ExceptionController extends ResponseEntityExceptionHandler {
 	public ResponseEntity<?> domainExceptionHandler(DomainException e) {
 		log.warn("[DomainException] {} : {}", e.status.getError(), e.status.getMessage());
 		if (log.isDebugEnabled()) {
-			log.debug(e);
+			log.debug("Exception stack trace: ", e);
 		}
 		return ResponseEntity
 				.status(e.status.getStatusCode())
@@ -74,7 +71,7 @@ public class ExceptionController extends ResponseEntityExceptionHandler {
 	public ResponseEntity<?> utilExceptionHandler(UtilException e) {
 		log.warn("[UtilException] {} : {}", e.status.getError(), e.status.getMessage());
 		if (log.isDebugEnabled()) {
-			log.debug(e);
+			log.debug("Exception stack trace: ", e);
 		}
 		return ResponseEntity
 				.status(e.status.getStatusCode())

--- a/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionController.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionController.java
@@ -1,18 +1,37 @@
 package org.ftclub.cabinet.exception;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.ftclub.cabinet.alarm.discord.DiscordWebAlarmMessage;
+import org.ftclub.cabinet.alarm.discord.DiscordWebHookMessenger;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @Log4j2
 @RestControllerAdvice
-public class ExceptionController {
+@RequiredArgsConstructor
+public class ExceptionController extends ResponseEntityExceptionHandler {
+
+	private final DiscordWebHookMessenger discordWebHookMessenger;
+	private static final String DEFAULT_ERROR_MESSAGE_VALUE = "까비 서버에서 예기치 않은 오류가 발생했어요.🥲";
+	private static final String SPRING_MVC_ERROR_MESSAGE_VALUE = "Spring MVC 에서 예기치 않은 오류가 발생했어요.🥲";
 
 	@ExceptionHandler(ControllerException.class)
 	public ResponseEntity<?> controllerExceptionHandler(ControllerException e) {
-		log.info("[ControllerException] {} : {}", e.status.getError(), e.status.getMessage());
-		e.printStackTrace();
+		StackTraceElement stackTraceElement = e.getStackTrace()[0];
+		log.info("[ControllerException] {} : {} at {}",
+				e.status.getError(), e.status.getMessage(),
+				stackTraceElement);
+		if (log.isDebugEnabled()) {
+			log.debug(e);
+		}
 		return ResponseEntity
 				.status(e.status.getStatusCode())
 				.body(e.status);
@@ -21,7 +40,9 @@ public class ExceptionController {
 	@ExceptionHandler(ServiceException.class)
 	public ResponseEntity<?> serviceExceptionHandler(ServiceException e) {
 		log.info("[ServiceException] {} : {}", e.status.getError(), e.status.getMessage());
-		e.printStackTrace();
+		if (log.isDebugEnabled()) {
+			log.debug(e);
+		}
 		return ResponseEntity
 				.status(e.status.getStatusCode())
 				.body(e.status);
@@ -30,6 +51,9 @@ public class ExceptionController {
 	@ExceptionHandler(CustomServiceException.class)
 	public ResponseEntity<?> customServiceExceptionHandler(CustomServiceException e) {
 		log.info("[CustomServiceException] {} : {}", e.status.getError(), e.status.getMessage());
+		if (log.isDebugEnabled()) {
+			log.debug(e);
+		}
 		return ResponseEntity
 				.status(e.status.getStatusCode())
 				.body(e.status);
@@ -38,6 +62,9 @@ public class ExceptionController {
 	@ExceptionHandler(DomainException.class)
 	public ResponseEntity<?> domainExceptionHandler(DomainException e) {
 		log.warn("[DomainException] {} : {}", e.status.getError(), e.status.getMessage());
+		if (log.isDebugEnabled()) {
+			log.debug(e);
+		}
 		return ResponseEntity
 				.status(e.status.getStatusCode())
 				.body(e.status);
@@ -46,9 +73,65 @@ public class ExceptionController {
 	@ExceptionHandler(UtilException.class)
 	public ResponseEntity<?> utilExceptionHandler(UtilException e) {
 		log.warn("[UtilException] {} : {}", e.status.getError(), e.status.getMessage());
+		if (log.isDebugEnabled()) {
+			log.debug(e);
+		}
 		return ResponseEntity
 				.status(e.status.getStatusCode())
 				.body(e.status);
 	}
 
+	@NotNull
+	@Override
+	protected ResponseEntity<Object> handleExceptionInternal(
+			@NotNull Exception e, Object body,
+			@NotNull org.springframework.http.HttpHeaders headers,
+			@NotNull org.springframework.http.HttpStatus status,
+			@NotNull org.springframework.web.context.request.WebRequest request) {
+		Map<String, Object> responseBody = new LinkedHashMap<>();
+		String requestUri = request.getContextPath();  // requestURI 정보 설정
+		responseBody.put("statusCode", status.value());
+		responseBody.put("message", e.getMessage());
+		responseBody.put("error", status.getReasonPhrase());
+
+		if (status.is5xxServerError()) {
+			responseBody.put("message", DEFAULT_ERROR_MESSAGE_VALUE);
+			log.error("[SpringMVCException] {} : {} at {}",
+					status.getReasonPhrase(), e.getMessage(), requestUri);
+			log.error("Exception stack trace: ", e);
+			discordWebHookMessenger.sendMessage(
+					DiscordWebAlarmMessage.fromWebRequest(
+							request,
+							SPRING_MVC_ERROR_MESSAGE_VALUE,
+							responseBody.toString()
+					)
+			);
+		} else {
+			log.warn("[SpringMVCException] {} : {} at {}",
+					status.getReasonPhrase(), e.getMessage(), requestUri);
+		}
+		return ResponseEntity.status(status).headers(headers).body(responseBody);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ResponseEntity<Object> handleInternalServerErrorException(Exception e,
+			HttpServletRequest request) {
+		log.error("[UncheckedException] {} for request URL: {}", e.getMessage(),
+				request.getRequestURL());
+		log.error("Exception stack trace: ", e);
+
+		Map<String, Object> responseBody = new LinkedHashMap<>();
+		responseBody.put("statusCode", HttpStatus.INTERNAL_SERVER_ERROR.value());
+		responseBody.put("message", DEFAULT_ERROR_MESSAGE_VALUE);
+		responseBody.put("error", HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase());
+
+		discordWebHookMessenger.sendMessage(
+				DiscordWebAlarmMessage.fromHttpServletRequest(
+						request,
+						DEFAULT_ERROR_MESSAGE_VALUE,
+						responseBody.toString()
+				)
+		);
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(responseBody);
+	}
 }

--- a/backend/src/main/resources/log4j2-prod.xml
+++ b/backend/src/main/resources/log4j2-prod.xml
@@ -1,6 +1,7 @@
 <Configuration status="info">
   <Properties>
-    <Property name="pattern" value="%style{%d{yyyy-MM-dd HH:mm:ss}}{white} %highlight{%-5level }[%style{%t}{bright,blue}] %style{%X}{normal, white} %style{%C{1}}{bright,yellow}: %msg%n%throwable"/>
+    <Property name="pattern"
+      value="%style{%d{yyyy-MM-dd HH:mm:ss}}{white} %highlight{%-5level }[%style{%t}{bright,blue}] %style{%X}{normal, white} %style{%C{1}}{bright,yellow}: %msg%n%throwable"/>
   </Properties>
 
   <Appenders>
@@ -8,7 +9,8 @@
       <PatternLayout pattern="${pattern}"/>
     </Console>
 
-    <RollingFile name="rollingFile" fileName="logs/42cabi.log" filePattern="logs/42cabi-%d{yyyy-MM-dd}-%i.log.gz">
+    <RollingFile name="rollingFile" fileName="logs/42cabi.log"
+      filePattern="logs/42cabi-%d{yyyy-MM-dd}-%i.log.gz">
       <PatternLayout pattern="${pattern}"/>
       <Policies>
         <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
@@ -20,16 +22,6 @@
         </Delete>
       </DefaultRolloverStrategy>
     </RollingFile>
-
-    <Http name="discordWebhook" url="${spring:webhook.discord-logging}" method="POST">
-      <Property name="Content-Type">application/json</Property>
-      <PatternLayout>
-        <Pattern>
-          {"content": "Profile: Main | %encode{%d{yyyy-MM-dd HH:mm:ss} [%t] %-5level: %m%n}{JSON}"}
-        </Pattern>
-      </PatternLayout>
-      <ThresholdFilter level="ERROR" onMatch="ACCEPT" onMismatch="DENY"/>
-    </Http>
   </Appenders>
 
   <Loggers>


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1593

<img width="849" alt="스크린샷 2024-04-16 오후 11 31 19" src="https://github.com/innovationacademy-kr/Cabi/assets/83565255/2eb420a8-4d84-4eb3-aff0-30835ad8d1a3">

사진과 같이 확인된(Checked) 에러가 디스코드로 알림을 오는 부분이 불편하다고 느껴, 모든 에러 로그를 알림보내지 않도록 `log4j2.xml`을 수정했습니다.


<img width="496" alt="스크린샷 2024-04-16 오후 11 22 56" src="https://github.com/innovationacademy-kr/Cabi/assets/83565255/2fb0b7d3-66b6-424f-884e-27ae011dd1e5">

<img width="770" alt="스크린샷 2024-04-16 오후 11 24 01" src="https://github.com/innovationacademy-kr/Cabi/assets/83565255/335f372c-b195-4d1d-8037-8d868987ba28">

다음과 같이 확인되지 않은 에러만 (서버측 에러의 확률이 높은 에러) 500 에러로 표시하여 응답하고, ERROR 레벨로 로그를 남긴 후, 디스코드로 알림을 보내도록 개선했습니다.




<img width="524" alt="스크린샷 2024-04-16 오후 11 21 27" src="https://github.com/innovationacademy-kr/Cabi/assets/83565255/7f9a9d13-d080-4970-a38a-e000706a1f5d">

<img width="1370" alt="스크린샷 2024-04-16 오후 11 21 35" src="https://github.com/innovationacademy-kr/Cabi/assets/83565255/8bc43bb3-f703-44fc-80ef-a656b0eb93dd">

또한 `ExceptionController`가 `ResponseEntityExceptionHandler`를 구현하도록 하여 우리가 처리할 수 없는 Spring MVC에서 발생시키는 클라이언트 측 에러를 `커스텀 에러 형식(statusCode, message, error)`에 맞게 변환하여 응답하도록 개선했습니다.
이 역시 확인되지 않은 500번대 에러만 ERROR 레벨로 로그를 남기고 알림을 보내고, 그렇지 않은 경우에는 WARN 레벨로 로그를 남기도록 구현했습니다.


