### PR TITLE
[BE] HOTFIX: 연체 스케줄러 NPE 수정 #1597

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/alarm/discord/DiscordScheduleAlarmMessage.java
+++ b/backend/src/main/java/org/ftclub/cabinet/alarm/discord/DiscordScheduleAlarmMessage.java
@@ -1,0 +1,30 @@
+package org.ftclub.cabinet.alarm.discord;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class DiscordScheduleAlarmMessage {
+
+	private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(
+			"yyyy-MM-dd HH:mm:ss");
+	private final String subject;
+	private final String taskName;
+	private final String taskMethodName;
+	private final String taskParameters;
+
+	@Override
+	public String toString() {
+		return "```java\n" +
+				"Subject: \"" + subject + "\"\n" +
+				"Task: \"" + taskName + "\"\n" +
+				"Issued at: \"" + LocalDateTime.now().format(formatter) + "\"\n" +
+				"Method: \"" + taskMethodName + "\"\n" +
+				"Parameters: \"" + taskParameters + "\"\n" +
+				"```";
+	}
+}
+

--- a/backend/src/main/java/org/ftclub/cabinet/alarm/discord/DiscordWebHookMessenger.java
+++ b/backend/src/main/java/org/ftclub/cabinet/alarm/discord/DiscordWebHookMessenger.java
@@ -40,4 +40,29 @@ public class DiscordWebHookMessenger {
 				.bodyToMono(String.class)
 				.block();
 	}
+
+	public void sendMessage(DiscordScheduleAlarmMessage message) {
+		Map<String, String> body = new HashMap<>();
+		body.put(DISCORD_WEBHOOK_MESSAGE_KEY, message.toString());
+
+		WebClient.create().post()
+				.uri(discordWebHookUrl)
+				.bodyValue(body)
+				.retrieve()
+				.bodyToMono(String.class)
+				.block();
+	}
+
+	public void sendMessage(String title, String message) {
+		Map<String, String> body = new HashMap<>();
+		body.put(DISCORD_WEBHOOK_MESSAGE_KEY,
+				"```title: " + title + "\nmessage: " + message + "```");
+
+		WebClient.create().post()
+				.uri(discordWebHookUrl)
+				.bodyValue(body)
+				.retrieve()
+				.bodyToMono(String.class)
+				.block();
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/dto/ActiveLentHistoryDto.java
+++ b/backend/src/main/java/org/ftclub/cabinet/dto/ActiveLentHistoryDto.java
@@ -1,5 +1,6 @@
 package org.ftclub.cabinet.dto;
 
+import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -14,5 +15,6 @@ public class ActiveLentHistoryDto {
 	private final String email;
 	private final Long cabinetId;
 	private final Boolean isExpired;
+	@Nullable
 	private final Long daysFromExpireDate;
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentHistory.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentHistory.java
@@ -3,6 +3,7 @@ package org.ftclub.cabinet.lent.domain;
 import static javax.persistence.FetchType.LAZY;
 
 import java.time.LocalDateTime;
+import javax.annotation.Nullable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -210,11 +211,12 @@ public class LentHistory {
 	}
 
 	/**
-	 * 만료일까지 남은 일수를 계산합니다. 만료시간이 설정되지 않았으면 null을 반환합니다.
+	 * 만료일까지 남은 일수를 계산합니다. 만료일이 설정되지 않았을 경우 {@code null}을 반환합니다.
 	 *
-	 * @return 만료일까지 남은 일수 (만료일 - 현재시간) (일 기준, 올림)
+	 * @param now 현재 시간을 나타내는 {@code LocalDateTime} 객체
+	 * @return 만료일까지 남은 일수를 일 단위로 반환합니다. 만료일이 설정되지 않았을 경우 {@code null} 반환.
 	 */
-	public Long getDaysUntilExpiration(LocalDateTime now) {
+	public @Nullable Long getDaysUntilExpiration(LocalDateTime now) {
 		if (isSetExpiredAt()) {
 			return DateUtil.calculateTwoDateDiffCeil(expiredAt, now);
 		}

--- a/backend/src/main/java/org/ftclub/cabinet/mapper/LentMapper.java
+++ b/backend/src/main/java/org/ftclub/cabinet/mapper/LentMapper.java
@@ -3,6 +3,7 @@ package org.ftclub.cabinet.mapper;
 import static org.mapstruct.NullValueMappingStrategy.RETURN_DEFAULT;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import org.ftclub.cabinet.cabinet.domain.Cabinet;
 import org.ftclub.cabinet.club.domain.ClubLentHistory;
 import org.ftclub.cabinet.dto.ActiveLentHistoryDto;
@@ -55,6 +56,6 @@ public interface LentMapper {
 			User user,
 			Cabinet cabinet,
 			Boolean isExpired,
-			Long daysLeftFromExpireDate
+			@Nullable Long daysLeftFromExpireDate
 	);
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1597

## NPE 오류 수정
<img width="392" alt="image" src="https://github.com/innovationacademy-kr/Cabi/assets/83565255/ebd6a45a-a2be-4d85-9adc-27ba86b38735">

`daysFromExpireDate`값이 null이 될 수 있어 발생한 오류였습니다. (사용하는 측에서 null의 프로퍼티 참조 시도 -> NPE 발생!)
`LentHistory.getDaysFromExpireDate()` 에서 null을 반환하는 것 자체가 안티 패턴이라고 생각합니다.
**그런데** 이미 음수 자체가 `연체전`이라는 의미를 가지고 있고, null 값 역시 `만료일 미설정`이라는 의미를 가지고 있어 null 반환 대신 사용할 적절한 대안을 찾지 못했어요.....

그래서 NPE 발생하는 부분 예외처리를 적용하고, 주석과 `@Nullable` 마크업 어노테이션을 달아 명시해두었습니다..!
제 딴에는 최선이라고 생각했지만... 혹시 다른 해결 방안이 있으시다면 말씀해주세요!!
핫픽스이기는 하지만 스케줄러가 자정에 돌기 때문에 자정 전까지는 merge 하지는 않겠습니다.

## 스케줄러 오류 알림 & 오류 발생 시 중단 버그 수정
<img width="619" alt="스크린샷 2024-04-19 오후 5 46 20" src="https://github.com/innovationacademy-kr/Cabi/assets/83565255/f160b75e-9af5-4320-a3aa-546aaf99024f">

<img width="1215" alt="스크린샷 2024-04-19 오후 9 05 25" src="https://github.com/innovationacademy-kr/Cabi/assets/83565255/fbb2b6d7-117f-409a-b4bf-b1652ffc2c6c">


또 스케줄러 함수의 루프 내에서 태스크 처리 중 에러가 발생하면 디스코드로 웹 훅을 전송하고, 루프가 중단되지 않도록 설정했습니다..! (고의적으로 에러를 발생시킨 사진입니다.)
