### PR TITLE
[BE] FIX: 연체 처리 NPE 오류 수정 #1597

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/dto/ActiveLentHistoryDto.java
+++ b/backend/src/main/java/org/ftclub/cabinet/dto/ActiveLentHistoryDto.java
@@ -1,6 +1,5 @@
 package org.ftclub.cabinet.dto;
 
-import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -15,6 +14,5 @@ public class ActiveLentHistoryDto {
 	private final String email;
 	private final Long cabinetId;
 	private final Boolean isExpired;
-	@Nullable
 	private final Long daysFromExpireDate;
 }

--- a/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentHistory.java
+++ b/backend/src/main/java/org/ftclub/cabinet/lent/domain/LentHistory.java
@@ -160,18 +160,19 @@ public class LentHistory {
 				new DomainException(ExceptionStatus.INVALID_STATUS));
 	}
 
-	/**
-	 * 만료일이 설정 되어있는 지 확인합니다. 만료일이 {@link DateUtil}의 infinityDate와 같으면 만료일이 설정되어 있지 않다고 판단합니다.
-	 *
-	 * @return 설정이 되어있으면 true 아니면 false
-	 */
-	public boolean isSetExpiredAt() {
-		LocalDateTime expiredAt = getExpiredAt();
-		if (expiredAt == null) {
-			throw ExceptionStatus.INTERNAL_SERVER_ERROR.asDomainException();
-		}
-		return !expiredAt.isEqual(DateUtil.getInfinityDate());
-	}
+//	NOTE: 2024-04-20 기준 정책상 만료일이 설정되어 있지 않은 경우는 없으므로 삭제
+//	/**
+//	 * 만료일이 설정 되어있는 지 확인합니다. 만료일이 {@link DateUtil}의 infinityDate와 같으면 만료일이 설정되어 있지 않다고 판단합니다.
+//	 *
+//	 * @return 설정이 되어있으면 true 아니면 false
+//	 */
+//	public boolean isSetExpiredAt() {
+//		LocalDateTime expiredAt = getExpiredAt();
+//		if (expiredAt == null) {
+//			throw ExceptionStatus.INTERNAL_SERVER_ERROR.asDomainException();
+//		}
+//		return !expiredAt.isEqual(DateUtil.getInfinityDate());
+//	}
 
 	/**
 	 * 반납일이 설정 되어있는 지 확인합니다. 반납일이 {@link DateUtil}의 infinityDate와 같으면 만료일이 설정되어 있지 않다고 판단합니다.
@@ -192,10 +193,14 @@ public class LentHistory {
 	 * @return endedAt - expiredAt의 값을(일 기준)
 	 */
 	public Long getDaysDiffEndedAndExpired() {
-		if (isSetExpiredAt() && isSetEndedAt()) {
+//		if (isSetExpiredAt() && isSetEndedAt()) {
+//			return DateUtil.calculateTwoDateDiff(endedAt, expiredAt) + 1;
+//		}
+//		return null;
+		if (isSetEndedAt()) {
 			return DateUtil.calculateTwoDateDiff(endedAt, expiredAt) + 1;
 		}
-		return null;
+		throw ExceptionStatus.INTERNAL_SERVER_ERROR.asDomainException();
 	}
 
 	/**
@@ -204,23 +209,25 @@ public class LentHistory {
 	 * @return 만료일이 지났으면 true 아니면 false, 만료일이 설정되어 있지 않으면 false
 	 */
 	public Boolean isExpired(LocalDateTime now) {
-		if (isSetExpiredAt()) {
-			return DateUtil.calculateTwoDateDiffCeil(expiredAt, now) > 0;
-		}
-		return false;
+//		if (isSetExpiredAt()) {
+//			return DateUtil.calculateTwoDateDiffCeil(expiredAt, now) > 0;
+//		}
+//		return false;
+		return DateUtil.calculateTwoDateDiffCeil(expiredAt, now) > 0;
 	}
 
 	/**
-	 * 만료일까지 남은 일수를 계산합니다. 만료일이 설정되지 않았을 경우 {@code null}을 반환합니다.
+	 * 만료일까지 남은 일수를 계산합니다.
 	 *
 	 * @param now 현재 시간을 나타내는 {@code LocalDateTime} 객체
-	 * @return 만료일까지 남은 일수를 일 단위로 반환합니다. 만료일이 설정되지 않았을 경우 {@code null} 반환.
+	 * @return 만료일까지 남은 일수를 일 단위로 반환합니다.
 	 */
-	public @Nullable Long getDaysUntilExpiration(LocalDateTime now) {
-		if (isSetExpiredAt()) {
-			return DateUtil.calculateTwoDateDiffCeil(expiredAt, now);
-		}
-		return null;
+	public Long getDaysUntilExpiration(LocalDateTime now) {
+//		if (isSetExpiredAt()) {
+//			return DateUtil.calculateTwoDateDiffCeil(expiredAt, now);
+//		}
+//		return null;
+		return DateUtil.calculateTwoDateDiffCeil(expiredAt, now);
 	}
 
 

--- a/backend/src/main/java/org/ftclub/cabinet/mapper/LentMapper.java
+++ b/backend/src/main/java/org/ftclub/cabinet/mapper/LentMapper.java
@@ -56,6 +56,6 @@ public interface LentMapper {
 			User user,
 			Cabinet cabinet,
 			Boolean isExpired,
-			@Nullable Long daysLeftFromExpireDate
+			Long daysFromExpireDate
 	);
 }

--- a/backend/src/test/java/org/ftclub/cabinet/lent/domain/LentHistoryTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/lent/domain/LentHistoryTest.java
@@ -33,13 +33,13 @@ class LentHistoryTest {
 		assertFalse(lentHistory.isCabinetIdEqual(2L));
 	}
 
-	@Test
-	void isSetExpiredAt() {
-		LocalDateTime now = LocalDateTime.now();
-		LentHistory lentHistory = LentHistory.of(now, now.plusDays(3), 1L, 1L);
-		assertTrue(lentHistory.isSetExpiredAt());
-		assertThrows(DomainException.class, () -> LentHistory.of(now, null, 1L, 1L));
-	}
+//	@Test
+//	void isSetExpiredAt() {
+//		LocalDateTime now = LocalDateTime.now();
+//		LentHistory lentHistory = LentHistory.of(now, now.plusDays(3), 1L, 1L);
+//		assertTrue(lentHistory.isSetExpiredAt());
+//		assertThrows(DomainException.class, () -> LentHistory.of(now, null, 1L, 1L));
+//	}
 
 	@Test
 	void isSetEndedAt() {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1597

- 레거시 정책 코드 제거 ex. LentHistory.isSetExpired() 제거
- 실제로 NPE 문제를 유발했던 LentMapper의 필드를 ActiveLentHistoryDto의 daysFromExpireDate와 동일하도록 수정
