### PR TITLE
[BE] FIX: 커스텀 에러 (확인된 예외)는 알림을 발송하지 않도록 수정 #1602

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/exception/ControllerException.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/ControllerException.java
@@ -4,19 +4,19 @@ package org.ftclub.cabinet.exception;
 import lombok.Getter;
 
 @Getter
-public class ControllerException extends RuntimeException {
+public class ControllerException extends RuntimeException implements FtClubCabinetException {
 
-    final ExceptionStatus status;
+	final ExceptionStatus status;
 
-    /**
-     * @param status exception에 대한 정보에 대한 enum
-     */
-    public ControllerException(ExceptionStatus status) {
-        this.status = status;
-    }
+	/**
+	 * @param status exception에 대한 정보에 대한 enum
+	 */
+	public ControllerException(ExceptionStatus status) {
+		this.status = status;
+	}
 
-    @Override
-    public String getMessage() {
-    	return status.getMessage();
-    }
+	@Override
+	public String getMessage() {
+		return status.getMessage();
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/exception/CustomServiceException.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/CustomServiceException.java
@@ -2,27 +2,28 @@ package org.ftclub.cabinet.exception;
 
 /**
  * Service에서 throw 하는 Exception 중 오류메세지를 커스텀 가능한 Exception
+ *
  * @see CustomExceptionStatus
  */
-public class CustomServiceException extends RuntimeException {
+public class CustomServiceException extends RuntimeException implements FtClubCabinetException {
 
-    final CustomExceptionStatus status;
+	final CustomExceptionStatus status;
 
-    /**
-     * @param status exception에 대한 정보에 대한 enum
-     */
-    public CustomServiceException(CustomExceptionStatus status) {
-        this.status = status;
-    }
+	/**
+	 * @param status exception에 대한 정보에 대한 enum
+	 */
+	public CustomServiceException(CustomExceptionStatus status) {
+		this.status = status;
+	}
 
-    public CustomExceptionStatus getStatus() {
-        return status;
-    }
+	public CustomExceptionStatus getStatus() {
+		return status;
+	}
 
-    @Override
-    public String getMessage() {
-    	return status.getMessage();
-    }
+	@Override
+	public String getMessage() {
+		return status.getMessage();
+	}
 
 
 }

--- a/backend/src/main/java/org/ftclub/cabinet/exception/DomainException.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/DomainException.java
@@ -3,7 +3,7 @@ package org.ftclub.cabinet.exception;
 import lombok.Getter;
 
 @Getter
-public class DomainException extends RuntimeException {
+public class DomainException extends RuntimeException implements FtClubCabinetException {
 
 	final ExceptionStatus status;
 

--- a/backend/src/main/java/org/ftclub/cabinet/exception/FtClubCabinetException.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/FtClubCabinetException.java
@@ -1,0 +1,9 @@
+package org.ftclub.cabinet.exception;
+
+/**
+ * FtClubCabinet 패키지에서 발생하는 예외들의 최상위 인터페이스 이 인터페이스를 구현하는 예외들은 FtClubCabinet 패키지에서 발생한 예외임을 나타냅니다.
+ * 커스텀 예외를 만들 때 이 인터페이스를 구현하도록 합니다.
+ */
+public interface FtClubCabinetException {
+
+}

--- a/backend/src/main/java/org/ftclub/cabinet/exception/ServiceException.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/ServiceException.java
@@ -9,23 +9,23 @@ package org.ftclub.cabinet.exception;
  *
  * @see org.ftclub.cabinet.exception.ExceptionStatus
  */
-public class ServiceException extends RuntimeException {
+public class ServiceException extends RuntimeException implements FtClubCabinetException {
 
-    final ExceptionStatus status;
+	final ExceptionStatus status;
 
-    /**
-     * @param status exception에 대한 정보에 대한 enum
-     */
-    public ServiceException(ExceptionStatus status) {
-        this.status = status;
-    }
+	/**
+	 * @param status exception에 대한 정보에 대한 enum
+	 */
+	public ServiceException(ExceptionStatus status) {
+		this.status = status;
+	}
 
-    public ExceptionStatus getStatus() {
-        return status;
-    }
+	public ExceptionStatus getStatus() {
+		return status;
+	}
 
-    @Override
-    public String getMessage() {
-        return status.getMessage();
-    }
+	@Override
+	public String getMessage() {
+		return status.getMessage();
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/exception/UtilException.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/UtilException.java
@@ -4,12 +4,13 @@ package org.ftclub.cabinet.exception;
  * Util에서 throw하는 exception들을 위한 exception 사용 예시:
  * <pre>
  *     {@code throw new UtilException(ExceptionStatus.NOT_FOUND_USER);}
- *</pre>
+ * </pre>
  * 만약 새로운 exception을 만들 필요가 있다면 {@link ExceptionStatus}에서 새로운 enum값을 추가하면 된다.
+ *
  * @see org.ftclub.cabinet.exception.ExceptionStatus
  */
 
-public class UtilException extends RuntimeException {
+public class UtilException extends RuntimeException implements FtClubCabinetException {
 
 	final ExceptionStatus status;
 

--- a/backend/src/main/java/org/ftclub/cabinet/utils/scheduler/SystemScheduler.java
+++ b/backend/src/main/java/org/ftclub/cabinet/utils/scheduler/SystemScheduler.java
@@ -9,6 +9,7 @@ import org.ftclub.cabinet.alarm.discord.DiscordScheduleAlarmMessage;
 import org.ftclub.cabinet.alarm.discord.DiscordWebHookMessenger;
 import org.ftclub.cabinet.dto.ActiveLentHistoryDto;
 import org.ftclub.cabinet.dto.UserBlackHoleEvent;
+import org.ftclub.cabinet.exception.FtClubCabinetException;
 import org.ftclub.cabinet.lent.service.LentFacadeService;
 import org.ftclub.cabinet.user.service.LentExtensionManager;
 import org.ftclub.cabinet.user.service.UserQueryService;
@@ -39,9 +40,14 @@ public class SystemScheduler {
 	private final DiscordWebHookMessenger discordWebHookMessenger;
 
 	private void errorHandle(Exception e, DiscordScheduleAlarmMessage message) {
-		log.error("Error message: {}, Error occurred in scheduled task: ", message, e);
-		discordWebHookMessenger.sendMessage(message);
+		if (!(e instanceof FtClubCabinetException)) {
+			log.error("Error message: {}, Error occurred in scheduled task: ", message, e);
+			discordWebHookMessenger.sendMessage(message);
+		} else {
+			log.warn("Handled FtClubCabinetException, no notification sent: ", e);
+		}
 	}
+
 
 	/**
 	 * 매일 자정마다 대여 기록을 확인하여, 연체 메일 발송 및 휴학생 처리를 트리거


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1602

스케줄러 에러 핸들러 측에서 커스텀 에러(확인된 예외)도 error 로그를 찍고, 알림을 보내는 문제가 있었습니다.
커스텀 에러(확인된 예외)에 대한 공통 인터페이스(FtClubCabinetException)를 만든 후 이를 implements 하여 공통 타입으로 만들었습니다.
이후 스케줄러에서 catch 된 에러 타입이 FtClubCabinetException이 아닌 경우에만 error 로그를 찍고 알림을 보내도록 수정했습니다.

![image](https://github.com/innovationacademy-kr/Cabi/assets/83565255/b3a8973d-fe21-4963-9ae9-391dc90898e9)

로컬에서 인수 테스트를 진행하였고, 정상적으로 동작하는 것을 확인했습니다.
