### PR TITLE
[FE] FEAT: 로컬스토리지에 --default-main-color값 있을 경우 해당 아이템 지움#1551

### DIFF
--- a/frontend/src/Cabinet/pages/Layout.tsx
+++ b/frontend/src/Cabinet/pages/Layout.tsx
@@ -99,6 +99,7 @@ const Layout = (): JSX.Element => {
   };
 
   useEffect(() => {
+    deleteOldPointColors();
     if (!token && !isLoginPage) navigate("/login");
     else if (token) {
       getMyInfo();
@@ -111,6 +112,15 @@ const Layout = (): JSX.Element => {
       return () => clearInterval(serverTimer);
     }
   }, []);
+
+  const deleteOldPointColors = () => {
+    localStorage.getItem("main-color") === "var(--default-main-color)" &&
+      localStorage.removeItem("main-color");
+    localStorage.getItem("sub-color") === "var(--default-sub-color)" &&
+      localStorage.removeItem("sub-color");
+    localStorage.getItem("mine-color") === "var(--default-mine-color)" &&
+      localStorage.removeItem("mine-color");
+  };
 
   const savedMainColor =
     localStorage.getItem("main-color") || "var(--sys-default-main-color)";

--- a/frontend/src/Cabinet/pages/ProfilePage.tsx
+++ b/frontend/src/Cabinet/pages/ProfilePage.tsx
@@ -82,7 +82,7 @@ const CardGridWrapper = styled.div`
 
   @media (max-width: 768px) {
     grid-template-columns: 350px;
-    grid-template-rows: 163px 366px 183px 230px 230px;
+    grid-template-rows: 163px 366px 183px 230px 348px;
     grid-template-areas:
       "profile"
       "lentInfo"

--- a/frontend/src/Cabinet/pages/admin/AdminLayout.tsx
+++ b/frontend/src/Cabinet/pages/admin/AdminLayout.tsx
@@ -32,12 +32,22 @@ const Layout = (): JSX.Element => {
   const isSearchPage: boolean = location.pathname === "/admin/search";
 
   useEffect(() => {
+    deleteOldPointColors();
     if (!token && !isLoginPage) navigate("/admin/login");
     else if (token) {
       setIsLoading(true);
       if (checkPath()) navigate("/admin/home");
     }
   }, []);
+
+  const deleteOldPointColors = () => {
+    localStorage.getItem("main-color") === "var(--default-main-color)" &&
+      localStorage.removeItem("main-color");
+    localStorage.getItem("sub-color") === "var(--default-sub-color)" &&
+      localStorage.removeItem("sub-color");
+    localStorage.getItem("mine-color") === "var(--default-mine-color)" &&
+      localStorage.removeItem("mine-color");
+  };
 
   const savedMainColor =
     localStorage.getItem("main-color") || "var(--sys-default-main-color)";


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

자세한 문제 상황 설명 -> https://github.com/innovationacademy-kr/42cabi/issues/1551

### 해결
`Layout`에서 로컬스토리지에서 `main-color`의 값이 `"var(--default-main-color)"`이면 해당 아이템 삭제. (`main-color` 뿐만 아니라 `sub-color`, `mine-color`도 마찬가지)
```
localStorage.getItem("main-color") === "var(--default-main-color)" && localStorage.removeItem("main-color");
```
