### PR TITLE
[FE] FIX: intra id로 검색하고 사물함 정보 눌렀을때 잘못된 cabinetInfoArea 뜨는것 해결#1604

### DIFF
--- a/frontend/src/Cabinet/pages/admin/AdminLayout.tsx
+++ b/frontend/src/Cabinet/pages/admin/AdminLayout.tsx
@@ -102,12 +102,10 @@ const Layout = (): JSX.Element => {
             {selectedTypeOnSearch === CabinetDetailAreaType.ITEM && (
               <UserStoreInfoArea />
             )}
-            {selectedTypeOnSearch === CabinetDetailAreaType.CABINET &&
-              (isMainPage ? (
-                <CabinetInfoAreaContainer />
-              ) : (
-                <UserCabinetInfoAreaContainer />
-              ))}
+
+            {selectedTypeOnSearch === CabinetDetailAreaType.CABINET && (
+              <CabinetInfoAreaContainer />
+            )}
           </DetailInfoContainerStyled>
           <MapInfoContainer />
           <AdminItemUsageLogPage />


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>어드민에서 사용정지 유저가 아닌 반납지연 유저를 검색하고 사물함 정보 버튼을 눌렀을때 대여 중이 아닌 사용자가 아닌 대여중인 사물함의 구역이 떠야함.

![image](https://github.com/innovationacademy-kr/Cabi/assets/80810728/030ceca7-48e8-4196-80a6-9e1b1fd2775e)

https://github.com/innovationacademy-kr/42cabi/issues/1635
