### PR TITLE
[BE] REFACTOR: 유저 현재 보유 재화를 REDIS -> RDBMS 이전 #1647

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/admin/item/service/AdminItemFacadeService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/item/service/AdminItemFacadeService.java
@@ -18,6 +18,7 @@ import org.ftclub.cabinet.item.service.ItemHistoryQueryService;
 import org.ftclub.cabinet.item.service.ItemQueryService;
 import org.ftclub.cabinet.item.service.ItemRedisService;
 import org.ftclub.cabinet.mapper.ItemMapper;
+import org.ftclub.cabinet.user.service.UserQueryService;
 import org.ftclub.cabinet.utils.lock.LockUtil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,6 +36,7 @@ public class AdminItemFacadeService {
 	private final ItemMapper itemMapper;
 
 	private final ItemRedisService itemRedisService;
+	private final UserQueryService userQueryService;
 
 	@Transactional
 	public void createItem(Integer Price, Sku sku, ItemType type) {
@@ -48,7 +50,7 @@ public class AdminItemFacadeService {
 		if (item.getPrice() > 0) {
 			now = LocalDateTime.now();
 			userIds.forEach(userId -> LockUtil.lockRedisCoin(userId, () -> {
-				long coinAmount = itemRedisService.getCoinAmount(userId);
+				long coinAmount = userQueryService.getUser(userId).getCoin();
 				itemRedisService.saveCoinCount(userId, coinAmount + item.getPrice());
 
 				long totalCoinSupply = itemRedisService.getTotalCoinSupply();

--- a/backend/src/main/java/org/ftclub/cabinet/admin/item/service/AdminItemFacadeService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/item/service/AdminItemFacadeService.java
@@ -20,7 +20,6 @@ import org.ftclub.cabinet.item.service.ItemRedisService;
 import org.ftclub.cabinet.mapper.ItemMapper;
 import org.ftclub.cabinet.user.service.UserCommandService;
 import org.ftclub.cabinet.user.service.UserQueryService;
-import org.ftclub.cabinet.utils.lock.LockUtil;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -53,8 +52,6 @@ public class AdminItemFacadeService {
 		if (price > 0) {
 			now = LocalDateTime.now();
 			userIds.forEach(userId -> {
-				long coinAmount = itemRedisService.getCoinAmount(userId);
-			userIds.forEach(userId -> LockUtil.lockRedisCoin(userId, () -> {
 				long coinAmount = userQueryService.getUser(userId).getCoin();
 				itemRedisService.saveCoinCount(userId, coinAmount + item.getPrice());
 

--- a/backend/src/main/java/org/ftclub/cabinet/admin/lent/service/AdminLentFacadeService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/lent/service/AdminLentFacadeService.java
@@ -74,7 +74,6 @@ public class AdminLentFacadeService {
 		LocalDateTime now = LocalDateTime.now();
 		List<LentHistory> lentHistories =
 				lentQueryService.findUserActiveLentHistoriesInCabinetForUpdate(userIds.get(0));
-		System.out.println("lentHistories = " + lentHistories);
 		if (lentHistories.isEmpty()) {
 			Long cabinetId = lentRedisService.findCabinetJoinedUser(userIds.get(0));
 			if (cabinetId != null) {

--- a/backend/src/main/java/org/ftclub/cabinet/item/service/ItemFacadeService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/item/service/ItemFacadeService.java
@@ -43,6 +43,7 @@ import org.ftclub.cabinet.log.LogLevel;
 import org.ftclub.cabinet.log.Logging;
 import org.ftclub.cabinet.mapper.ItemMapper;
 import org.ftclub.cabinet.user.domain.User;
+import org.ftclub.cabinet.user.service.UserCommandService;
 import org.ftclub.cabinet.user.service.UserQueryService;
 import org.ftclub.cabinet.utils.lock.LockUtil;
 import org.springframework.context.ApplicationEventPublisher;
@@ -67,6 +68,7 @@ public class ItemFacadeService {
 	private final ItemMapper itemMapper;
 	private final ItemPolicyService itemPolicyService;
 	private final ApplicationEventPublisher eventPublisher;
+	private final UserCommandService userCommandService;
 
 
 	/**
@@ -207,6 +209,7 @@ public class ItemFacadeService {
 
 		// Redis에 코인 변화량 저장
 		saveCoinChangeOnRedis(userId, reward);
+		userCommandService.updateCoinAmount(userId, (long) reward);
 
 		return new CoinCollectionRewardResponseDto(reward);
 	}
@@ -315,6 +318,7 @@ public class ItemFacadeService {
 			long totalCoinUsage = itemRedisService.getTotalCoinUsage();
 			itemRedisService.saveTotalCoinUsage(totalCoinUsage + price);
 		});
+		userCommandService.updateCoinAmount(userId, price);
 	}
 
 	@Transactional

--- a/backend/src/main/java/org/ftclub/cabinet/item/service/ItemFacadeService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/item/service/ItemFacadeService.java
@@ -214,8 +214,8 @@ public class ItemFacadeService {
 	private void saveCoinChangeOnRedis(Long userId, final int reward) {
 		LockUtil.lockRedisCoin(userId, () -> {
 			// Redis에 유저 리워드 저장
-			long coins = itemRedisService.getCoinAmount(userId);
-			itemRedisService.saveCoinCount(userId, coins + reward);
+//			long coins = itemRedisService.getCoinAmount(userId);
+//			itemRedisService.saveCoinCount(userId, coins + reward);
 
 			// Redis에 전체 코인 발행량 저장
 			long totalCoinSupply = itemRedisService.getTotalCoinSupply();
@@ -294,7 +294,11 @@ public class ItemFacadeService {
 
 		Item item = itemQueryService.getBySku(sku);
 		long price = item.getPrice();
-		long userCoin = itemRedisService.getCoinAmount(userId);
+
+		// 유저의 보유 재화량
+//		long userCoin = itemRedisService.getCoinAmount(userId);
+		long userCoin = user.getCoin();
+
 
 		// 아이템 Policy 검증
 		itemPolicyService.verifyOnSale(price);

--- a/backend/src/main/java/org/ftclub/cabinet/item/service/ItemRedisService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/item/service/ItemRedisService.java
@@ -15,19 +15,6 @@ public class ItemRedisService {
 	private final ItemRedis itemRedis;
 	private final ItemHistoryRepository itemHistoryRepository;
 
-	public long getCoinAmount(Long userId) {
-		String userIdString = userId.toString();
-		String coinAmount = itemRedis.getCoinAmount(userIdString);
-		if (coinAmount == null) {
-			long coin = itemHistoryRepository.findAllByUserId(userId).stream()
-					.mapToLong(ih -> ih.getItem().getPrice())
-					.reduce(Long::sum).orElse(0L);
-			itemRedis.saveCoinAmount(userIdString, Long.toString(coin));
-			return coin;
-		}
-		return Integer.parseInt(coinAmount);
-	}
-
 	public void saveCoinCount(Long userId, long coinCount) {
 		itemRedis.saveCoinAmount(userId.toString(), String.valueOf(coinCount));
 	}

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
@@ -147,4 +147,8 @@ public class User {
 	public boolean isBlackholed() {
 		return blackholedAt != null && blackholedAt.isBefore(LocalDateTime.now());
 	}
+
+	public void addCoin(Long reward) {
+		this.coin += reward;
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
@@ -69,6 +69,7 @@ public class User {
 		this.name = name;
 		this.email = email;
 		this.blackholedAt = blackholedAt;
+		this.coin = 0L;
 //		this.role = userRole;
 		setDefaultAlarmStatus();
 	}

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
@@ -61,6 +61,9 @@ public class User {
 	@Column(name = "PUSH_ALARM", columnDefinition = "boolean default false")
 	private boolean pushAlarm;
 
+	@NotNull
+	@Column(name = "COIN", columnDefinition = "bigint default 0")
+	private Long coin;
 
 	protected User(String name, String email, LocalDateTime blackholedAt) {
 		this.name = name;

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionManager.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionManager.java
@@ -59,8 +59,8 @@ public class LentExtensionManager {
 	 */
 	private void saveCoinChangeOnRedis(Long userId, long price) {
 		// 유저 재화 변동량 Redis에 저장
-		long userCoinCount = itemRedisService.getCoinAmount(userId);
-		itemRedisService.saveCoinCount(userId, userCoinCount + price);
+//		long userCoinCount = itemRedisService.getCoinAmount(userId);
+//		itemRedisService.saveCoinCount(userId, userCoinCount + price);
 
 		// 전체 재화 변동량 Redis에 저장
 		long totalCoinSupply = itemRedisService.getTotalCoinSupply();

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionManager.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/LentExtensionManager.java
@@ -14,7 +14,6 @@ import org.ftclub.cabinet.log.LogLevel;
 import org.ftclub.cabinet.log.Logging;
 import org.ftclub.cabinet.occupiedtime.OccupiedTimeManager;
 import org.ftclub.cabinet.user.domain.User;
-import org.ftclub.cabinet.utils.lock.LockUtil;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -43,10 +42,10 @@ public class LentExtensionManager {
 
 		List<User> users = userQueryService.findAllUsersByNames(userNames);
 		Item coinRewardItem = itemQueryService.getBySku(Sku.COIN_FULL_TIME);
+
 		users.forEach(user -> {
 			Long userId = user.getId();
-			LockUtil.lockRedisCoin(userId, () ->
-					saveCoinChangeOnRedis(userId, coinRewardItem.getPrice()));
+			user.addCoin(coinRewardItem.getPrice());
 			itemHistoryCommandService.createItemHistory(userId, coinRewardItem.getId());
 		});
 	}

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/UserCommandService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/UserCommandService.java
@@ -109,4 +109,10 @@ public class UserCommandService {
 		user.changeBlackholedAt(blackholedAt);
 		userRepository.save(user);
 	}
+
+	public void updateCoinAmount(Long userId, Long reward) {
+		User user = userRepository.findById(userId)
+				.orElseThrow(ExceptionStatus.NOT_FOUND_USER::asServiceException);
+		user.addCoin(reward);
+	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/user/service/UserFacadeService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/service/UserFacadeService.java
@@ -70,7 +70,7 @@ public class UserFacadeService {
 		AlarmTypeResponseDto userAlarmTypes = currentUser.getAlarmTypes();
 		boolean isDeviceTokenExpired = userAlarmTypes.isPush()
 				&& fcmTokenRedisService.findByUserName(user.getName()).isEmpty();
-		Long coins = itemRedisService.getCoinAmount(userId);
+		Long coins = currentUser.getCoin();
 		return userMapper.toMyProfileResponseDto(user, cabinet, banHistory,
 				lentExtensionResponseDto, userAlarmTypes, isDeviceTokenExpired, coins);
 	}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1647


- LentExtensionManager 
issueLentExtension() 연장권 만큼의 재화 지급
연장권 발급시 2000 코인 지급 user에 직접 add 형태로 변경
- ItemFacadeService, 
- AdminItemFacadeService

assignItem()  아이템 지급
Redis 관련함수 삭제
```itemRedisService.getCoinAmount(userId);```
```userQueryService.getUser(userId).getCoin();```

 ```userCommandService.updateCoinAmount(userId, price);``` 
함수를 이용하도록 수정



ItemFacadeService
purchaseItem() 아이템 구매


