### PR TITLE
[FE] FEAT: 센트리 도입 #1665

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -8,6 +8,8 @@
   "arrowParens": "always",
   "importOrder": [
     "<THIRD_PARTY_MODULES>",
+    "^@/.*\\.css$",
+    "^@/App",
     "^@/Cabinet/recoil/(.*)$",
     "^@/Cabinet/pages/(.*)$",
     "^@/Cabinet/components/(.*)$",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -39,6 +39,7 @@
         "@typescript-eslint/eslint-plugin": "^5.46.1",
         "@typescript-eslint/parser": "^5.46.1",
         "@vitejs/plugin-react": "^3.0.0",
+        "babel-plugin-styled-components": "^2.1.4",
         "date-fns": "^3.6.0",
         "eslint": "^8.30.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -66,7 +67,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
       "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -91,7 +91,6 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
       "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -100,7 +99,6 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
       "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
-      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -180,7 +178,6 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
       "integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
-      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
         "@babel/helper-validator-option": "^7.22.15",
@@ -196,7 +193,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -204,8 +200,7 @@
     "node_modules/@babel/helper-compilation-targets/node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.22.15",
@@ -321,7 +316,6 @@
       "version": "7.23.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz",
       "integrity": "sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-module-imports": "^7.22.15",
@@ -352,7 +346,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
       "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -395,7 +388,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
       "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-      "dev": true,
       "dependencies": {
         "@babel/types": "^7.22.5"
       },
@@ -446,7 +438,6 @@
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
       "integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -469,7 +460,6 @@
       "version": "7.23.2",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
       "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
-      "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.15",
         "@babel/traverse": "^7.23.2",
@@ -668,7 +658,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.22.5.tgz",
       "integrity": "sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
       },
@@ -2827,7 +2816,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
       "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.0.0",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -4872,24 +4860,19 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
-      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
+      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-module-imports": "^7.16.0",
-        "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11",
-        "picomatch": "^2.3.0"
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
+        "lodash": "^4.17.21",
+        "picomatch": "^2.3.1"
       },
       "peerDependencies": {
         "styled-components": ">= 2"
       }
-    },
-    "node_modules/babel-plugin-syntax-jsx": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw=="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -4929,7 +4912,6 @@
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
       "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5018,7 +5000,6 @@
       "version": "1.0.30001551",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001551.tgz",
       "integrity": "sha512-vtBAez47BoGMMzlbYhfXrMV1kvRF2WP/lqiMuDu1Sb4EE4LKEgjopFDSRtZfdVnslNRpOqV/woE+Xgrwj6VQlg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5192,8 +5173,7 @@
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
     "node_modules/cookie": {
       "version": "0.4.2",
@@ -5736,8 +5716,7 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.559",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.559.tgz",
-      "integrity": "sha512-iS7KhLYCSJbdo3rUSkhDTVuFNCV34RKs2UaB9Ecr7VlqzjjWW//0nfsFF5dtDmyXlZQaDYYtID5fjtC/6lpRug==",
-      "dev": true
+      "integrity": "sha512-iS7KhLYCSJbdo3rUSkhDTVuFNCV34RKs2UaB9Ecr7VlqzjjWW//0nfsFF5dtDmyXlZQaDYYtID5fjtC/6lpRug=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -6816,7 +6795,6 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -8075,7 +8053,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -8443,8 +8420,7 @@
     "node_modules/node-releases": {
       "version": "2.0.13",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
-      "dev": true
+      "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ=="
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -8759,8 +8735,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -9421,7 +9396,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -10090,7 +10064,6 @@
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
       "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "@nivo/pie": "^0.80.0",
         "@sentry/react": "^8.18.0",
         "@types/react-color": "^3.0.7",
-        "axios": "^1.2.1",
+        "axios": "^1.7.2",
         "firebase": "^10.4.0",
         "react": "^18.2.0",
         "react-color": "^2.19.3",
@@ -4817,11 +4817,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.1.tgz",
-      "integrity": "sha512-I88cFiGu9ryt/tfVEi4kX2SITsvDddTajXTOFmt2uK1ZVA8LytjtdeyefdQWEf5PU8w+4SSJDoYnggflB5tW4A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
@@ -6719,9 +6719,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@nivo/core": "^0.80.0",
         "@nivo/line": "^0.80.0",
         "@nivo/pie": "^0.80.0",
+        "@sentry/react": "^8.18.0",
         "@types/react-color": "^3.0.7",
         "axios": "^1.2.1",
         "firebase": "^10.4.0",
@@ -3250,6 +3251,126 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.18.0.tgz",
+      "integrity": "sha512-1R7QXp7Gu6ovJGWvGjbgHcDcvDstsQba3miHtUCyDSH9kXtnAVLCAItDkseetFh+JLsjBXf3QFi2H3HPY4hRCw==",
+      "dependencies": {
+        "@sentry/core": "8.18.0",
+        "@sentry/types": "8.18.0",
+        "@sentry/utils": "8.18.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.18.0.tgz",
+      "integrity": "sha512-on6+4ZRkfdnsNgXecGQ6ME8aO26VTzkuM6y/kNN+bG2hSdxsmuU957B4x1Z5wEXiOWswuf3rhqGepg8JIdPkMQ==",
+      "dependencies": {
+        "@sentry/core": "8.18.0",
+        "@sentry/types": "8.18.0",
+        "@sentry/utils": "8.18.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.18.0.tgz",
+      "integrity": "sha512-cCLib/HjD8UR0fB2F5hV6KsFBD6yTOEsi67RBllm5gT5vJt87VYoPliF6O7mmMNw8TWkQ0uc5laKld3q9ph+ug==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.18.0",
+        "@sentry/core": "8.18.0",
+        "@sentry/types": "8.18.0",
+        "@sentry/utils": "8.18.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.18.0.tgz",
+      "integrity": "sha512-fcuLJBrhw3Ql8sU8veUgDCRYo6toQldFU807cpYphQ0uEw2oVZwNNPDQSu1651Ykvp0P/x+9hk/jjJxMohrO9g==",
+      "dependencies": {
+        "@sentry-internal/replay": "8.18.0",
+        "@sentry/core": "8.18.0",
+        "@sentry/types": "8.18.0",
+        "@sentry/utils": "8.18.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.18.0.tgz",
+      "integrity": "sha512-E2w9u76JcjxcmgvroJrB7bcbG5oBCYI/pME1CtprBgZSS9mMYDsyBe6JKqGHdw2wvT3xNxNtkm7hf1O6+3NWUQ==",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.18.0",
+        "@sentry-internal/feedback": "8.18.0",
+        "@sentry-internal/replay": "8.18.0",
+        "@sentry-internal/replay-canvas": "8.18.0",
+        "@sentry/core": "8.18.0",
+        "@sentry/types": "8.18.0",
+        "@sentry/utils": "8.18.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.18.0.tgz",
+      "integrity": "sha512-8moEMC3gp4W6mH9w5amb/zrYk6bNW8WGgcLRMCs5rguxny8YP5i8ISOJ0T0LP9x/RxSK/6xix5D2bzI/5ECzlw==",
+      "dependencies": {
+        "@sentry/types": "8.18.0",
+        "@sentry/utils": "8.18.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.18.0.tgz",
+      "integrity": "sha512-ckCKdxmeFdfR6moE/Aiq+cJyQuCUKoUqU/++xZwqVbgecuImsk4s7CzzpX9T6JoYK7jqru2SvuRSiwcdtLN6AQ==",
+      "dependencies": {
+        "@sentry/browser": "8.18.0",
+        "@sentry/core": "8.18.0",
+        "@sentry/types": "8.18.0",
+        "@sentry/utils": "8.18.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.18.0.tgz",
+      "integrity": "sha512-5J+uOqptnmAnW3Rk31AHIqW36Wzvlo3UOM+p2wjSYGrC/PgcE47Klzr+w4UcOhN6AZqefalGd3vaUXz9NaFdRg==",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.18.0.tgz",
+      "integrity": "sha512-7wq7cgaeSIGJncl9/2VMu81ZN5ep4lp4H1/+O8+xUxOmnPb/05ZZcbn9/VxVQvIoqZSZdwCLPeBz6PEVukvokA==",
+      "dependencies": {
+        "@sentry/types": "8.18.0"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -6648,6 +6769,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "@typescript-eslint/eslint-plugin": "^5.46.1",
     "@typescript-eslint/parser": "^5.46.1",
     "@vitejs/plugin-react": "^3.0.0",
+    "babel-plugin-styled-components": "^2.1.4",
     "date-fns": "^3.6.0",
     "eslint": "^8.30.0",
     "eslint-config-airbnb": "^19.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
     "@nivo/core": "^0.80.0",
     "@nivo/line": "^0.80.0",
     "@nivo/pie": "^0.80.0",
+    "@sentry/react": "^8.18.0",
     "@types/react-color": "^3.0.7",
     "axios": "^1.2.1",
     "firebase": "^10.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "@nivo/pie": "^0.80.0",
     "@sentry/react": "^8.18.0",
     "@types/react-color": "^3.0.7",
-    "axios": "^1.2.1",
+    "axios": "^1.7.2",
     "firebase": "^10.4.0",
     "react": "^18.2.0",
     "react-color": "^2.19.3",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,9 +39,8 @@ const AdminLoginFailurePage = lazy(
 );
 const AdminHomePage = lazy(() => import("@/Cabinet/pages/admin/AdminHomePage"));
 
-const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
-
 function App(): React.ReactElement {
+  const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
   return (
     <BrowserRouter>
       {/* GA4 Page Tracking Component */}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import PageTracker from "@/api/analytics/PageTracker";
+import * as Sentry from "@sentry/react";
 import React, { Suspense, lazy } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import AvailablePage from "@/Cabinet/pages/AvailablePage";
@@ -38,57 +39,64 @@ const AdminLoginFailurePage = lazy(
 );
 const AdminHomePage = lazy(() => import("@/Cabinet/pages/admin/AdminHomePage"));
 
+const SentryRoutes = Sentry.withSentryReactRouterV6Routing(Routes);
+
 function App(): React.ReactElement {
   return (
     <BrowserRouter>
       {/* GA4 Page Tracking Component */}
       <PageTracker />
       <Suspense fallback={<LoadingAnimation />}>
-        <Routes>
-          <Route path="/post-login" element={<PostLogin />} />
-          <Route path="/" element={<Layout />}>
-            <Route path="login" element={<LoginPage />} />
-            <Route path="home" element={<HomePage />} />
-            <Route path="main" element={<MainPage />} />
-            <Route path="available" element={<AvailablePage />} />
-            <Route path="profile" element={<ProfilePage />} />
-            <Route path="profile/log" element={<LogPage />} />
-            <Route path="clubs" element={<ClubPage />} />
-            <Route path="store" element={<StoreMainPage />} />
-            <Route path="store/inventory" element={<InventoryPage />} />
-            <Route path="store/item-use-log" element={<ItemUsageLogPage />} />
-            <Route path="store/coin-log" element={<CoinLogPage />} />
-          </Route>
-          <Route path="/presentation/" element={<PresentationLayout />}>
-            <Route path="home" element={<PresentationHomePage />} />
-            <Route path="register" element={<RegisterPage />} />
-            <Route path="detail" element={<DetailPage />} />
-            <Route path="log" element={<PresentationLogPage />} />
-          </Route>
-          {/* admin용 라우터 */}
-          <Route path="/admin/" element={<AdminLayout />}>
-            <Route path="login" element={<AdminLoginPage />} />
-            <Route path="home" element={<AdminHomePage />} />
-            <Route path="main" element={<AdminMainPage />} />
-            <Route path="search" element={<SearchPage />} />
-            <Route path="club" element={<AdminClubPage />} />
-            <Route path="slack-notification" element={<AdminSlackNotiPage />} />
-            <Route path="available" element={<AvailablePage />} />
-            <Route path="store" element={<AdminStorePage />} />
-          </Route>
-          <Route
-            path="/admin/presentation/"
-            element={<AdminPresentationLayout />}
-          >
-            <Route path="detail" element={<DetailPage />} />
-          </Route>
-          <Route path="/login/failure" element={<LoginFailurePage />} />
-          <Route
-            path="/admin/login/failure"
-            element={<AdminLoginFailurePage />}
-          />
-          <Route path="/*" element={<NotFoundPage />} />
-        </Routes>
+        <SentryRoutes>
+          <Routes>
+            <Route path="/post-login" element={<PostLogin />} />
+            <Route path="/" element={<Layout />}>
+              <Route path="login" element={<LoginPage />} />
+              <Route path="home" element={<HomePage />} />
+              <Route path="main" element={<MainPage />} />
+              <Route path="available" element={<AvailablePage />} />
+              <Route path="profile" element={<ProfilePage />} />
+              <Route path="profile/log" element={<LogPage />} />
+              <Route path="clubs" element={<ClubPage />} />
+              <Route path="store" element={<StoreMainPage />} />
+              <Route path="store/inventory" element={<InventoryPage />} />
+              <Route path="store/item-use-log" element={<ItemUsageLogPage />} />
+              <Route path="store/coin-log" element={<CoinLogPage />} />
+            </Route>
+            <Route path="/presentation/" element={<PresentationLayout />}>
+              <Route path="home" element={<PresentationHomePage />} />
+              <Route path="register" element={<RegisterPage />} />
+              <Route path="detail" element={<DetailPage />} />
+              <Route path="log" element={<PresentationLogPage />} />
+            </Route>
+            {/* admin용 라우터 */}
+            <Route path="/admin/" element={<AdminLayout />}>
+              <Route path="login" element={<AdminLoginPage />} />
+              <Route path="home" element={<AdminHomePage />} />
+              <Route path="main" element={<AdminMainPage />} />
+              <Route path="search" element={<SearchPage />} />
+              <Route path="club" element={<AdminClubPage />} />
+              <Route
+                path="slack-notification"
+                element={<AdminSlackNotiPage />}
+              />
+              <Route path="available" element={<AvailablePage />} />
+              <Route path="store" element={<AdminStorePage />} />
+            </Route>
+            <Route
+              path="/admin/presentation/"
+              element={<AdminPresentationLayout />}
+            >
+              <Route path="detail" element={<DetailPage />} />
+            </Route>
+            <Route path="/login/failure" element={<LoginFailurePage />} />
+            <Route
+              path="/admin/login/failure"
+              element={<AdminLoginFailurePage />}
+            />
+            <Route path="/*" element={<NotFoundPage />} />
+          </Routes>
+        </SentryRoutes>
       </Suspense>
     </BrowserRouter>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,54 +48,49 @@ function App(): React.ReactElement {
       <PageTracker />
       <Suspense fallback={<LoadingAnimation />}>
         <SentryRoutes>
-          <Routes>
-            <Route path="/post-login" element={<PostLogin />} />
-            <Route path="/" element={<Layout />}>
-              <Route path="login" element={<LoginPage />} />
-              <Route path="home" element={<HomePage />} />
-              <Route path="main" element={<MainPage />} />
-              <Route path="available" element={<AvailablePage />} />
-              <Route path="profile" element={<ProfilePage />} />
-              <Route path="profile/log" element={<LogPage />} />
-              <Route path="clubs" element={<ClubPage />} />
-              <Route path="store" element={<StoreMainPage />} />
-              <Route path="store/inventory" element={<InventoryPage />} />
-              <Route path="store/item-use-log" element={<ItemUsageLogPage />} />
-              <Route path="store/coin-log" element={<CoinLogPage />} />
-            </Route>
-            <Route path="/presentation/" element={<PresentationLayout />}>
-              <Route path="home" element={<PresentationHomePage />} />
-              <Route path="register" element={<RegisterPage />} />
-              <Route path="detail" element={<DetailPage />} />
-              <Route path="log" element={<PresentationLogPage />} />
-            </Route>
-            {/* admin용 라우터 */}
-            <Route path="/admin/" element={<AdminLayout />}>
-              <Route path="login" element={<AdminLoginPage />} />
-              <Route path="home" element={<AdminHomePage />} />
-              <Route path="main" element={<AdminMainPage />} />
-              <Route path="search" element={<SearchPage />} />
-              <Route path="club" element={<AdminClubPage />} />
-              <Route
-                path="slack-notification"
-                element={<AdminSlackNotiPage />}
-              />
-              <Route path="available" element={<AvailablePage />} />
-              <Route path="store" element={<AdminStorePage />} />
-            </Route>
-            <Route
-              path="/admin/presentation/"
-              element={<AdminPresentationLayout />}
-            >
-              <Route path="detail" element={<DetailPage />} />
-            </Route>
-            <Route path="/login/failure" element={<LoginFailurePage />} />
-            <Route
-              path="/admin/login/failure"
-              element={<AdminLoginFailurePage />}
-            />
-            <Route path="/*" element={<NotFoundPage />} />
-          </Routes>
+          <Route path="/post-login" element={<PostLogin />} />
+          <Route path="/" element={<Layout />}>
+            <Route path="login" element={<LoginPage />} />
+            <Route path="home" element={<HomePage />} />
+            <Route path="main" element={<MainPage />} />
+            <Route path="available" element={<AvailablePage />} />
+            <Route path="profile" element={<ProfilePage />} />
+            <Route path="profile/log" element={<LogPage />} />
+            <Route path="clubs" element={<ClubPage />} />
+            <Route path="store" element={<StoreMainPage />} />
+            <Route path="store/inventory" element={<InventoryPage />} />
+            <Route path="store/item-use-log" element={<ItemUsageLogPage />} />
+            <Route path="store/coin-log" element={<CoinLogPage />} />
+          </Route>
+          <Route path="/presentation/" element={<PresentationLayout />}>
+            <Route path="home" element={<PresentationHomePage />} />
+            <Route path="register" element={<RegisterPage />} />
+            <Route path="detail" element={<DetailPage />} />
+            <Route path="log" element={<PresentationLogPage />} />
+          </Route>
+          {/* admin용 라우터 */}
+          <Route path="/admin/" element={<AdminLayout />}>
+            <Route path="login" element={<AdminLoginPage />} />
+            <Route path="home" element={<AdminHomePage />} />
+            <Route path="main" element={<AdminMainPage />} />
+            <Route path="search" element={<SearchPage />} />
+            <Route path="club" element={<AdminClubPage />} />
+            <Route path="slack-notification" element={<AdminSlackNotiPage />} />
+            <Route path="available" element={<AvailablePage />} />
+            <Route path="store" element={<AdminStorePage />} />
+          </Route>
+          <Route
+            path="/admin/presentation/"
+            element={<AdminPresentationLayout />}
+          >
+            <Route path="detail" element={<DetailPage />} />
+          </Route>
+          <Route path="/login/failure" element={<LoginFailurePage />} />
+          <Route
+            path="/admin/login/failure"
+            element={<AdminLoginFailurePage />}
+          />
+          <Route path="/*" element={<NotFoundPage />} />
         </SentryRoutes>
       </Suspense>
     </BrowserRouter>

--- a/frontend/src/Cabinet/api/axios/axios.custom.ts
+++ b/frontend/src/Cabinet/api/axios/axios.custom.ts
@@ -1,3 +1,4 @@
+import { captureException } from "@sentry/react";
 import { AlarmInfo } from "@/Cabinet/types/dto/alarm.dto";
 import { ClubUserDto } from "@/Cabinet/types/dto/lent.dto";
 import CabinetStatus from "@/Cabinet/types/enum/cabinet.status.enum";
@@ -241,6 +242,10 @@ export const axiosLentId = async (cabinetId: number | null): Promise<any> => {
     const response = await instance.post(`${axiosLentIdURL}${cabinetId}`);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: { type: "대여 에러" },
+    });
     throw error;
   }
 };
@@ -251,6 +256,10 @@ export const axiosMyLentInfo = async (): Promise<any> => {
     const response = await instance.get(axiosMyLentInfoURL);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: { type: "대여 에러" },
+    });
     throw error;
   }
 };
@@ -262,6 +271,10 @@ export const axiosSwapId = async (cabinetId: number | null): Promise<any> => {
     const response = await instance.post(`${axiosSwapIdURL}${cabinetId}`);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: { type: "대여 에러" },
+    });
     throw error;
   }
 };
@@ -278,6 +291,10 @@ export const axiosUpdateMyCabinetInfo = async (
     });
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: { type: "대여 에러" },
+    });
     throw error;
   }
 };
@@ -288,6 +305,10 @@ export const axiosReturn = async (): Promise<any> => {
     const response = await instance.patch(axiosReturnURL);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: { type: "반납 에러" },
+    });
     throw error;
   }
 };
@@ -299,6 +320,10 @@ export const axiosSendCabinetPassword = async (password: string) => {
       cabinetMemo: password,
     });
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: { type: "반납 에러" },
+    });
     throw error;
   }
 };
@@ -311,6 +336,10 @@ export const axiosMyLentLog = async (page: number): Promise<any> => {
     });
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: { type: "대여 에러" },
+    });
     throw error;
   }
 };
@@ -321,6 +350,10 @@ export const axiosExtendLentPeriod = async (): Promise<any> => {
     const response = await instance.patch(axiosExtendLentPeriodURL);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: { type: "대여 에러" },
+    });
     throw error;
   }
 };
@@ -838,6 +871,10 @@ export const axiosLentShareId = async (
     });
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: { type: "대여 에러" },
+    });
     throw error;
   }
 };
@@ -851,6 +888,10 @@ export const axiosCancel = async (cabinetId: number | null): Promise<any> => {
     const response = await instance.patch(`${axiosCancelURL}${cabinetId}`);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: { type: "대여 에러" },
+    });
     throw error;
   }
 };

--- a/frontend/src/Cabinet/api/axios/axios.custom.ts
+++ b/frontend/src/Cabinet/api/axios/axios.custom.ts
@@ -28,36 +28,6 @@ export const axiosMyInfo = async (): Promise<any> => {
   }
 };
 
-const axiosMyExtensionsInfoURL = "/v4/users/me/lent-extensions";
-export const axiosMyExtensionsInfo = async (): Promise<any> => {
-  try {
-    const response = await instance.get(axiosMyExtensionsInfoURL);
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
-
-const axiosActiveExtensionInfoURL = "/v4/users/me/lent-extensions/active";
-export const axiosActiveExtensionInfo = async (): Promise<any> => {
-  try {
-    const response = await instance.get(axiosActiveExtensionInfoURL);
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
-
-const axiosUseExtensionURL = "/v4/users/me/lent-extensions";
-export const axiosUseExtension = async (): Promise<any> => {
-  try {
-    const response = await instance.post(axiosUseExtensionURL);
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
-
 const axiosUpdateAlarmURL = "/v4/users/me/alarms";
 export const axiosUpdateAlarm = async (alarm: AlarmInfo): Promise<any> => {
   try {
@@ -260,18 +230,6 @@ export const axiosMyLentInfo = async (): Promise<any> => {
   }
 };
 
-const axiosSwapIdURL = "/v4/lent/swap/";
-export const axiosSwapId = async (cabinetId: number | null): Promise<any> => {
-  if (cabinetId === null) return;
-  try {
-    const response = await instance.post(`${axiosSwapIdURL}${cabinetId}`);
-    return response;
-  } catch (error) {
-    logAxiosError(error, ErrorType.LENT, "이사하기 중 오류 발생");
-    throw error;
-  }
-};
-
 const axiosUpdateMyCabinetInfoURL = "/v4/lent/me/cabinet";
 export const axiosUpdateMyCabinetInfo = async (
   title: string | null,
@@ -329,17 +287,6 @@ export const axiosMyLentLog = async (page: number): Promise<any> => {
     return response;
   } catch (error) {
     logAxiosError(error, ErrorType.LENT, "내 대여 기록 불러오는 중 오류 발생");
-    throw error;
-  }
-};
-
-const axiosExtendLentPeriodURL = "/v4/lent/cabinets/extend";
-export const axiosExtendLentPeriod = async (): Promise<any> => {
-  try {
-    const response = await instance.patch(axiosExtendLentPeriodURL);
-    return response;
-  } catch (error) {
-    logAxiosError(error, ErrorType.LENT, "연장권 사용 중 오류 발생");
     throw error;
   }
 };

--- a/frontend/src/Cabinet/api/axios/axios.custom.ts
+++ b/frontend/src/Cabinet/api/axios/axios.custom.ts
@@ -3,8 +3,10 @@ import { AlarmInfo } from "@/Cabinet/types/dto/alarm.dto";
 import { ClubUserDto } from "@/Cabinet/types/dto/lent.dto";
 import CabinetStatus from "@/Cabinet/types/enum/cabinet.status.enum";
 import CabinetType from "@/Cabinet/types/enum/cabinet.type.enum";
+import ErrorType from "@/Cabinet/types/enum/error.type.enum";
 import { CoinLogToggleType } from "@/Cabinet/types/enum/store.enum";
 import instance from "@/Cabinet/api/axios/axios.instance";
+import { logAxiosError } from "@/Cabinet/api/axios/axios.log";
 
 const axiosLogoutUrl = "/v4/auth/logout";
 export const axiosLogout = async (): Promise<any> => {
@@ -242,10 +244,7 @@ export const axiosLentId = async (cabinetId: number | null): Promise<any> => {
     const response = await instance.post(`${axiosLentIdURL}${cabinetId}`);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: { type: "대여 에러" },
-    });
+    logAxiosError(error, ErrorType.LENT, "개인사물함 대여 중 오류 발생");
     throw error;
   }
 };
@@ -256,10 +255,7 @@ export const axiosMyLentInfo = async (): Promise<any> => {
     const response = await instance.get(axiosMyLentInfoURL);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: { type: "대여 에러" },
-    });
+    logAxiosError(error, ErrorType.LENT, "내 대여 정보 불러오는 중 오류 발생");
     throw error;
   }
 };
@@ -271,10 +267,7 @@ export const axiosSwapId = async (cabinetId: number | null): Promise<any> => {
     const response = await instance.post(`${axiosSwapIdURL}${cabinetId}`);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: { type: "대여 에러" },
-    });
+    logAxiosError(error, ErrorType.LENT, "이사하기 중 오류 발생");
     throw error;
   }
 };
@@ -291,10 +284,11 @@ export const axiosUpdateMyCabinetInfo = async (
     });
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: { type: "대여 에러" },
-    });
+    logAxiosError(
+      error,
+      ErrorType.LENT,
+      "내 사물함 정보 업데이트 중 오류 발생"
+    );
     throw error;
   }
 };
@@ -305,10 +299,7 @@ export const axiosReturn = async (): Promise<any> => {
     const response = await instance.patch(axiosReturnURL);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: { type: "반납 에러" },
-    });
+    logAxiosError(error, ErrorType.RETURN, "사물함 반납 중 오류 발생");
     throw error;
   }
 };
@@ -320,10 +311,11 @@ export const axiosSendCabinetPassword = async (password: string) => {
       cabinetMemo: password,
     });
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: { type: "반납 에러" },
-    });
+    logAxiosError(
+      error,
+      ErrorType.RETURN,
+      "3층 사물함 비밀번호 재설정 & 반납 중 오류 발생"
+    );
     throw error;
   }
 };
@@ -336,10 +328,7 @@ export const axiosMyLentLog = async (page: number): Promise<any> => {
     });
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: { type: "대여 에러" },
-    });
+    logAxiosError(error, ErrorType.LENT, "내 대여 기록 불러오는 중 오류 발생");
     throw error;
   }
 };
@@ -350,10 +339,7 @@ export const axiosExtendLentPeriod = async (): Promise<any> => {
     const response = await instance.patch(axiosExtendLentPeriodURL);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: { type: "대여 에러" },
-    });
+    logAxiosError(error, ErrorType.LENT, "연장권 사용 중 오류 발생");
     throw error;
   }
 };

--- a/frontend/src/Cabinet/api/axios/axios.custom.ts
+++ b/frontend/src/Cabinet/api/axios/axios.custom.ts
@@ -114,7 +114,7 @@ export const axiosGetClubInfo = async (
 const axiosAddClubMemberURL = "/v4/clubs";
 export const axiosAddClubMember = async (
   clubId: number,
-  name: String
+  name: string
 ): Promise<any> => {
   // TODO : 예외처리?
   try {
@@ -434,7 +434,7 @@ export const axiosItems = async (): Promise<any> => {
 };
 
 const axiosBuyItemURL = "/v5/items/";
-export const axiosBuyItem = async (sku: String): Promise<any> => {
+export const axiosBuyItem = async (sku: string): Promise<any> => {
   try {
     const response = await instance.post(axiosBuyItemURL + sku + "/purchase");
     return response;
@@ -445,7 +445,7 @@ export const axiosBuyItem = async (sku: String): Promise<any> => {
 };
 
 export const axiosUseItem = async (
-  sku: String,
+  sku: string,
   newCabinetId: number | null,
   building: string | null,
   floor: number | null,
@@ -815,7 +815,8 @@ export const axiosStatisticsCoin = async () => {
     logAxiosError(
       error,
       ErrorType.STORE,
-      "전체 재화 현황 데이터 불러오는중 오류 발생"
+      "전체 재화 현황 데이터 불러오는중 오류 발생",
+      true
     );
     throw error;
   }
@@ -835,7 +836,8 @@ export const axiosCoinUseStatistics = async (
     logAxiosError(
       error,
       ErrorType.STORE,
-      "재화 사용 통계 데이터 불러오는중 오류 발생"
+      "재화 사용 통계 데이터 불러오는중 오류 발생",
+      true
     );
     throw error;
   }
@@ -850,7 +852,8 @@ export const axiosStatisticsTotalItemUse = async () => {
     logAxiosError(
       error,
       ErrorType.STORE,
-      "아이템 사용 통계 데이터 불러오는중 오류 발생"
+      "아이템 사용 통계 데이터 불러오는중 오류 발생",
+      true
     );
     throw error;
   }
@@ -870,7 +873,8 @@ export const axiosCoinCollectStatistics = async (
     logAxiosError(
       error,
       ErrorType.STORE,
-      "동전 줍기 통계 데이터 불러오는중 오류 발생"
+      "동전 줍기 통계 데이터 불러오는중 오류 발생",
+      true
     );
     throw error;
   }
@@ -966,7 +970,7 @@ export const axiosItemAssign = async (
     });
     return response;
   } catch (error) {
-    logAxiosError(error, ErrorType.STORE, "아이템 지급 중 오류 발생");
+    logAxiosError(error, ErrorType.STORE, "아이템 지급 중 오류 발생", true);
     throw error;
   }
 };
@@ -986,7 +990,8 @@ export const axiosGetUserItems = async (
     logAxiosError(
       error,
       ErrorType.STORE,
-      "어드민에서 유저 아이템 내역 불러오는중 오류 발생"
+      "유저 아이템 내역 불러오는중 오류 발생",
+      true
     );
     throw error;
   }

--- a/frontend/src/Cabinet/api/axios/axios.custom.ts
+++ b/frontend/src/Cabinet/api/axios/axios.custom.ts
@@ -350,12 +350,11 @@ export const axiosCoinCheckGet = async (): Promise<any> => {
     const response = await instance.get(axiosCoinCheck);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(
+      error,
+      ErrorType.STORE,
+      "동전 줍기 정보 불러오는 중 오류 발생"
+    );
     throw error;
   }
 };
@@ -365,12 +364,7 @@ export const axiosCoinCheckPost = async (): Promise<any> => {
     const response = await instance.post(axiosCoinCheck);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(error, ErrorType.STORE, "동전 줍기 중 오류 발생");
     throw error;
   }
 };
@@ -387,12 +381,7 @@ export const axiosCoinLog = async (
     });
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(error, ErrorType.STORE, "코인내역 불러오는중 오류 발생");
     throw error;
   }
 };
@@ -403,12 +392,7 @@ export const axiosMyItems = async (): Promise<any> => {
     const response = await instance.get(axiosMyItemsURL);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(error, ErrorType.STORE, "보유아이템 불러오는중 오류 발생");
     throw error;
   }
 };
@@ -425,12 +409,11 @@ export const axiosGetItemUsageHistory = async (
     });
     return response.data;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(
+      error,
+      ErrorType.STORE,
+      "아이템 사용내역 불러오는중 오류 발생"
+    );
     throw error;
   }
 };
@@ -441,12 +424,11 @@ export const axiosItems = async (): Promise<any> => {
     const response = await instance.get(axiosItemsURL);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(
+      error,
+      ErrorType.STORE,
+      "상점 아이템 목록 불러오는중 오류 발생"
+    );
     throw error;
   }
 };
@@ -457,12 +439,7 @@ export const axiosBuyItem = async (sku: String): Promise<any> => {
     const response = await instance.post(axiosBuyItemURL + sku + "/purchase");
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(error, ErrorType.STORE, "아이템 구매중 오류 발생");
     throw error;
   }
 };
@@ -483,12 +460,7 @@ export const axiosUseItem = async (
     });
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(error, ErrorType.STORE, "아이템 사용중 오류 발생");
     throw error;
   }
 };
@@ -840,12 +812,11 @@ export const axiosStatisticsCoin = async () => {
     const response = await instance.get(axiosStatisticsCoinURL);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(
+      error,
+      ErrorType.STORE,
+      "전체 재화 현황 데이터 불러오는중 오류 발생"
+    );
     throw error;
   }
 };
@@ -861,43 +832,26 @@ export const axiosCoinUseStatistics = async (
     });
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(
+      error,
+      ErrorType.STORE,
+      "재화 사용 통계 데이터 불러오는중 오류 발생"
+    );
     throw error;
   }
 };
 
-const axiosStatisticsItemURL = "/v5/admin/statistics/coins";
-export const axiosStatisticsItem = async () => {
-  try {
-    const response = await instance.get(axiosStatisticsItemURL);
-    return response;
-  } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
-    throw error;
-  }
-};
 const axiosStatisticsTotalItemUseURL = "/v5/admin/statistics/items";
 export const axiosStatisticsTotalItemUse = async () => {
   try {
     const response = await instance.get(axiosStatisticsTotalItemUseURL);
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(
+      error,
+      ErrorType.STORE,
+      "아이템 사용 통계 데이터 불러오는중 오류 발생"
+    );
     throw error;
   }
 };
@@ -913,12 +867,11 @@ export const axiosCoinCollectStatistics = async (
     });
     return response;
   } catch (error) {
-    captureException(error, {
-      level: "error",
-      extra: {
-        type: "재화 에러",
-      },
-    });
+    logAxiosError(
+      error,
+      ErrorType.STORE,
+      "동전 줍기 통계 데이터 불러오는중 오류 발생"
+    );
     throw error;
   }
 };
@@ -1013,22 +966,7 @@ export const axiosItemAssign = async (
     });
     return response;
   } catch (error) {
-    throw error;
-  }
-};
-
-const axiosItemAssignListURL = "/v5/admin/items/assign";
-export const axiosItemAssignList = async (
-  page: number,
-  size: number
-): Promise<any> => {
-  if (page === null || size === null) return;
-  try {
-    const response = await instance.get(axiosItemAssignListURL, {
-      params: { page: page, size: size },
-    });
-    return response.data;
-  } catch (error) {
+    logAxiosError(error, ErrorType.STORE, "아이템 지급 중 오류 발생");
     throw error;
   }
 };
@@ -1045,6 +983,11 @@ export const axiosGetUserItems = async (
     });
     return response;
   } catch (error) {
+    logAxiosError(
+      error,
+      ErrorType.STORE,
+      "어드민에서 유저 아이템 내역 불러오는중 오류 발생"
+    );
     throw error;
   }
 };

--- a/frontend/src/Cabinet/api/axios/axios.custom.ts
+++ b/frontend/src/Cabinet/api/axios/axios.custom.ts
@@ -364,6 +364,12 @@ export const axiosCoinCheckGet = async (): Promise<any> => {
     const response = await instance.get(axiosCoinCheck);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -373,6 +379,12 @@ export const axiosCoinCheckPost = async (): Promise<any> => {
     const response = await instance.post(axiosCoinCheck);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -389,6 +401,12 @@ export const axiosCoinLog = async (
     });
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -399,6 +417,12 @@ export const axiosMyItems = async (): Promise<any> => {
     const response = await instance.get(axiosMyItemsURL);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -415,6 +439,12 @@ export const axiosGetItemUsageHistory = async (
     });
     return response.data;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -425,6 +455,12 @@ export const axiosItems = async (): Promise<any> => {
     const response = await instance.get(axiosItemsURL);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -435,6 +471,12 @@ export const axiosBuyItem = async (sku: String): Promise<any> => {
     const response = await instance.post(axiosBuyItemURL + sku + "/purchase");
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -455,6 +497,12 @@ export const axiosUseItem = async (
     });
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -806,6 +854,12 @@ export const axiosStatisticsCoin = async () => {
     const response = await instance.get(axiosStatisticsCoinURL);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -821,6 +875,12 @@ export const axiosCoinUseStatistics = async (
     });
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -831,6 +891,12 @@ export const axiosStatisticsItem = async () => {
     const response = await instance.get(axiosStatisticsItemURL);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -840,6 +906,12 @@ export const axiosStatisticsTotalItemUse = async () => {
     const response = await instance.get(axiosStatisticsTotalItemUseURL);
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };
@@ -855,6 +927,12 @@ export const axiosCoinCollectStatistics = async (
     });
     return response;
   } catch (error) {
+    captureException(error, {
+      level: "error",
+      extra: {
+        type: "재화 에러",
+      },
+    });
     throw error;
   }
 };

--- a/frontend/src/Cabinet/api/axios/axios.instance.ts
+++ b/frontend/src/Cabinet/api/axios/axios.instance.ts
@@ -43,7 +43,7 @@ instance.interceptors.response.use(
         extra: { type: "서버 에러" },
       });
     }
-    return Promise.reject(new Error(error));
+    return Promise.reject(error);
   }
 );
 

--- a/frontend/src/Cabinet/api/axios/axios.instance.ts
+++ b/frontend/src/Cabinet/api/axios/axios.instance.ts
@@ -11,9 +11,7 @@ const instance = axios.create({
 
 instance.interceptors.request.use(async (config) => {
   const token = getCookie("admin_access_token") ?? getCookie("access_token");
-  config.headers = {
-    Authorization: `Bearer ${token}`,
-  };
+  config.headers.set("Authorization", `Bearer ${token}`);
   return config;
 });
 

--- a/frontend/src/Cabinet/api/axios/axios.instance.ts
+++ b/frontend/src/Cabinet/api/axios/axios.instance.ts
@@ -1,7 +1,6 @@
 import { captureException } from "@sentry/react";
 import axios, { HttpStatusCode } from "axios";
 import { getCookie, removeCookie } from "@/Cabinet/api/react_cookie/cookies";
-import { STATUS_401_UNAUTHORIZED } from "@/Cabinet/constants/StatusCode";
 
 axios.defaults.withCredentials = true;
 

--- a/frontend/src/Cabinet/api/axios/axios.instance.ts
+++ b/frontend/src/Cabinet/api/axios/axios.instance.ts
@@ -1,5 +1,6 @@
-import { captureException } from "@sentry/react";
 import axios, { HttpStatusCode } from "axios";
+import ErrorType from "@/Cabinet/types/enum/error.type.enum";
+import { logAxiosError } from "@/Cabinet/api/axios/axios.log";
 import { getCookie, removeCookie } from "@/Cabinet/api/react_cookie/cookies";
 
 axios.defaults.withCredentials = true;
@@ -38,10 +39,7 @@ instance.interceptors.response.use(
       window.location.href = "login";
       alert(error.response.data.message);
     } else if (error.response?.status === HttpStatusCode.InternalServerError) {
-      captureException(error, {
-        level: "error",
-        extra: { type: "서버 에러" },
-      });
+      logAxiosError(error, ErrorType.INTERNAL_SERVER_ERROR, "서버 에러");
     }
     return Promise.reject(error);
   }

--- a/frontend/src/Cabinet/api/axios/axios.log.ts
+++ b/frontend/src/Cabinet/api/axios/axios.log.ts
@@ -1,16 +1,26 @@
 import { captureException } from "@sentry/react";
 import { AxiosError } from "axios";
+import ErrorType from "@/Cabinet/types/enum/error.type.enum";
+import { getCookie } from "@/Cabinet/api/react_cookie/cookies";
 
-export function logAxiosError(error: AxiosError, type: string, errorMsg : string) {
-	error.message =  "[Axios] " + errorMsg;
-	captureException(error, {
-	  tags: {
-		// user:
-		api: error.response?.config.url,
-		httpMethod: error.config?.method?.toUpperCase(),
-		httpStatusCode: (error.response?.status || "").toString(),
-	  },
-	  level: "error",
-	  extra: { type: type },
-	});
-  }
+const token = getCookie("admin_access_token") ?? getCookie("access_token");
+const decodedPayload = JSON.parse(atob(token.split(".")[1]));
+const user = decodedPayload.name;
+
+export function logAxiosError(
+  error: AxiosError,
+  type: ErrorType,
+  errorMsg: string
+) {
+  error.message = "[Axios] " + errorMsg;
+  captureException(error, {
+    tags: {
+      user,
+      api: error.response?.config.url,
+      httpMethod: error.config?.method?.toUpperCase(),
+      httpStatusCode: (error.response?.status ?? "").toString(),
+    },
+    level: "error",
+    extra: { type: type },
+  });
+}

--- a/frontend/src/Cabinet/api/axios/axios.log.ts
+++ b/frontend/src/Cabinet/api/axios/axios.log.ts
@@ -1,5 +1,4 @@
 import { captureException } from "@sentry/react";
-import { AxiosError } from "axios";
 import ErrorType from "@/Cabinet/types/enum/error.type.enum";
 import { getCookie } from "@/Cabinet/api/react_cookie/cookies";
 

--- a/frontend/src/Cabinet/api/axios/axios.log.ts
+++ b/frontend/src/Cabinet/api/axios/axios.log.ts
@@ -12,7 +12,7 @@ export const logAxiosError = (
   type: ErrorType,
   errorMsg: string
 ) => {
-  error.message = "[Axios] " + errorMsg;
+  error.message = errorMsg;
   captureException(error, {
     tags: {
       userId: userId,

--- a/frontend/src/Cabinet/api/axios/axios.log.ts
+++ b/frontend/src/Cabinet/api/axios/axios.log.ts
@@ -5,7 +5,7 @@ import { getCookie } from "@/Cabinet/api/react_cookie/cookies";
 
 const token = getCookie("admin_access_token") ?? getCookie("access_token");
 const decodedPayload = JSON.parse(window.atob(token.split(".")[1]));
-const user = decodedPayload.name;
+const userId = decodedPayload.name;
 
 export const logAxiosError = (
   error: AxiosError,
@@ -15,7 +15,7 @@ export const logAxiosError = (
   error.message = "[Axios] " + errorMsg;
   captureException(error, {
     tags: {
-      user,
+      userId: userId,
       api: error.response?.config.url,
       httpMethod: error.config?.method?.toUpperCase(),
       httpStatusCode: (error.response?.status ?? "").toString(),

--- a/frontend/src/Cabinet/api/axios/axios.log.ts
+++ b/frontend/src/Cabinet/api/axios/axios.log.ts
@@ -19,6 +19,8 @@ export const logAxiosError = (
       api: error.response?.config.url,
       httpMethod: error.config?.method?.toUpperCase(),
       httpStatusCode: (error.response?.status ?? "").toString(),
+      environment:
+        import.meta.env.VITE_IS_LOCAL === "true" ? "local" : "production",
     },
     level: "error",
     extra: { type: type },

--- a/frontend/src/Cabinet/api/axios/axios.log.ts
+++ b/frontend/src/Cabinet/api/axios/axios.log.ts
@@ -4,14 +4,14 @@ import ErrorType from "@/Cabinet/types/enum/error.type.enum";
 import { getCookie } from "@/Cabinet/api/react_cookie/cookies";
 
 const token = getCookie("admin_access_token") ?? getCookie("access_token");
-const decodedPayload = JSON.parse(atob(token.split(".")[1]));
+const decodedPayload = JSON.parse(window.atob(token.split(".")[1]));
 const user = decodedPayload.name;
 
-export function logAxiosError(
+export const logAxiosError = (
   error: AxiosError,
   type: ErrorType,
   errorMsg: string
-) {
+) => {
   error.message = "[Axios] " + errorMsg;
   captureException(error, {
     tags: {
@@ -23,4 +23,4 @@ export function logAxiosError(
     level: "error",
     extra: { type: type },
   });
-}
+};

--- a/frontend/src/Cabinet/api/axios/axios.log.ts
+++ b/frontend/src/Cabinet/api/axios/axios.log.ts
@@ -10,9 +10,10 @@ const userId = decodedPayload.name;
 export const logAxiosError = (
   error: any,
   type: ErrorType,
-  errorMsg: string
+  errorMsg: string,
+  isAdmin = false
 ) => {
-  error.message = errorMsg;
+  error.message = (isAdmin ? "[Admin] " : "") + errorMsg;
   captureException(error, {
     tags: {
       userId: userId,

--- a/frontend/src/Cabinet/api/axios/axios.log.ts
+++ b/frontend/src/Cabinet/api/axios/axios.log.ts
@@ -8,7 +8,7 @@ const decodedPayload = JSON.parse(window.atob(token.split(".")[1]));
 const userId = decodedPayload.name;
 
 export const logAxiosError = (
-  error: AxiosError,
+  error: any,
   type: ErrorType,
   errorMsg: string
 ) => {

--- a/frontend/src/Cabinet/api/axios/axios.log.ts
+++ b/frontend/src/Cabinet/api/axios/axios.log.ts
@@ -1,0 +1,16 @@
+import { captureException } from "@sentry/react";
+import { AxiosError } from "axios";
+
+export function logAxiosError(error: AxiosError, type: string, errorMsg : string) {
+	error.message =  "[Axios] " + errorMsg;
+	captureException(error, {
+	  tags: {
+		// user:
+		api: error.response?.config.url,
+		httpMethod: error.config?.method?.toUpperCase(),
+		httpStatusCode: (error.response?.status || "").toString(),
+	  },
+	  level: "error",
+	  extra: { type: type },
+	});
+  }

--- a/frontend/src/Cabinet/components/Club/AdminClubLog.container.tsx
+++ b/frontend/src/Cabinet/components/Club/AdminClubLog.container.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import AdminClubLog from "@/Cabinet/components/Club/AdminClubLog";
 import { ClubLogResponseType, ClubUserDto } from "@/Cabinet/types/dto/lent.dto";
 import { axiosGetClubUserLog } from "@/Cabinet/api/axios/axios.custom";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
+import { HttpStatusCode } from "axios";
 
 const AdminClubLogContainer = (props: any) => {
   const [logs, setLogs] = useState<ClubLogResponseType>(undefined);
@@ -20,7 +20,7 @@ const AdminClubLogContainer = (props: any) => {
       } else setTotalPage(Math.ceil(result.data.totalLength / size));
       setLogs(result.data.result);
     } catch {
-      setLogs(STATUS_400_BAD_REQUEST);
+      setLogs(HttpStatusCode.BadRequest);
       setTotalPage(1);
     }
   };

--- a/frontend/src/Cabinet/components/Club/ClubInfo.tsx
+++ b/frontend/src/Cabinet/components/Club/ClubInfo.tsx
@@ -1,3 +1,4 @@
+import { HttpStatusCode } from "axios";
 import { useEffect, useState } from "react";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
@@ -10,7 +11,6 @@ import UnavailableDataInfo from "@/Cabinet/components/Common/UnavailableDataInfo
 import { ClubInfoResponseDto } from "@/Cabinet/types/dto/club.dto";
 import useClubInfo from "@/Cabinet/hooks/useClubInfo";
 import useMenu from "@/Cabinet/hooks/useMenu";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const ClubInfo = () => {
   const [myInfo] = useRecoilState(userState);
@@ -20,7 +20,7 @@ const ClubInfo = () => {
 
   useEffect(() => {
     closeAll();
-    if (clubInfo && clubInfo !== STATUS_400_BAD_REQUEST) {
+    if (clubInfo && clubInfo !== HttpStatusCode.BadRequest) {
       let clubInfoTest = clubInfo as ClubInfoResponseDto;
       if (clubInfoTest.clubMaster.userName === myInfo.name) setIsMaster(true);
     }
@@ -30,7 +30,7 @@ const ClubInfo = () => {
     <>
       {clubInfo === undefined ? (
         <LoadingAnimation />
-      ) : clubInfo === STATUS_400_BAD_REQUEST ? (
+      ) : clubInfo === HttpStatusCode.BadRequest ? (
         <>
           <UnavailableDataInfo msg="동아리 사물함이 없어요" />
         </>

--- a/frontend/src/Cabinet/components/Club/ClubLogTable.tsx
+++ b/frontend/src/Cabinet/components/Club/ClubLogTable.tsx
@@ -1,9 +1,9 @@
+import { HttpStatusCode } from "axios";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
 import { selectedClubInfoState } from "@/Cabinet/recoil/atoms";
 import LoadingAnimation from "@/Cabinet/components/Common/LoadingAnimation";
 import { ClubLogResponseType, ClubUserDto } from "@/Cabinet/types/dto/lent.dto";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const ClubLogTable = ({ ClubList }: { ClubList: ClubLogResponseType }) => {
   const [selectedClubInfo, setSelectedClubInfo] = useRecoilState(
@@ -20,7 +20,7 @@ const ClubLogTable = ({ ClubList }: { ClubList: ClubLogResponseType }) => {
 
   return (
     <>
-      {ClubList !== STATUS_400_BAD_REQUEST && ClubList.length !== 0 ? (
+      {ClubList !== HttpStatusCode.BadRequest && ClubList.length !== 0 ? (
         <LogTableWrapperStyled>
           <LogTableStyled>
             <TheadStyled>

--- a/frontend/src/Cabinet/components/ItemLog/AdminItemProvideLog.container.tsx
+++ b/frontend/src/Cabinet/components/ItemLog/AdminItemProvideLog.container.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import AdminItemProvideLog from "@/Cabinet/components/ItemLog/AdminItemProvideLog";
 import { ItemLogResponseType } from "@/Cabinet/types/dto/admin.dto";
 import useMenu from "@/Cabinet/hooks/useMenu";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const AdminItemProvideLogContainer = () => {
   const { closeStore } = useMenu();

--- a/frontend/src/Cabinet/components/ItemLog/ItemLogTable/AdminItemLogTable.tsx
+++ b/frontend/src/Cabinet/components/ItemLog/ItemLogTable/AdminItemLogTable.tsx
@@ -1,8 +1,8 @@
+import { HttpStatusCode } from "axios";
 import styled from "styled-components";
 import LoadingAnimation from "@/Cabinet/components/Common/LoadingAnimation";
 import { ItemLogResponseType } from "@/Cabinet/types/dto/admin.dto";
 import { formatDate } from "@/Cabinet/utils/dateUtils";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const AdminItemLogTable = ({ itemLog }: { itemLog: ItemLogResponseType }) => {
   if (!itemLog) return <LoadingAnimation />;
@@ -16,7 +16,7 @@ const AdminItemLogTable = ({ itemLog }: { itemLog: ItemLogResponseType }) => {
             <th>사용일</th>
           </tr>
         </TheadStyled>
-        {itemLog !== STATUS_400_BAD_REQUEST &&
+        {itemLog !== HttpStatusCode.BadRequest &&
           Array.isArray(itemLog.itemHistories) && (
             <TbodyStyled>
               {itemLog.itemHistories.map(
@@ -47,7 +47,7 @@ const AdminItemLogTable = ({ itemLog }: { itemLog: ItemLogResponseType }) => {
             </TbodyStyled>
           )}
       </LogTableStyled>
-      {(itemLog === STATUS_400_BAD_REQUEST ||
+      {(itemLog === HttpStatusCode.BadRequest ||
         itemLog.totalLength === undefined ||
         itemLog.totalLength === 0) && (
         <EmptyLogStyled>아이템 내역이 없습니다.</EmptyLogStyled>

--- a/frontend/src/Cabinet/components/ItemLog/ItemLogTable/AdminItemProvideTable.tsx
+++ b/frontend/src/Cabinet/components/ItemLog/ItemLogTable/AdminItemProvideTable.tsx
@@ -1,8 +1,8 @@
+import { HttpStatusCode } from "axios";
 import styled from "styled-components";
 import LoadingAnimation from "@/Cabinet/components/Common/LoadingAnimation";
 import { ItemLogResponseType } from "@/Cabinet/types/dto/admin.dto";
 import { formatDate } from "@/Cabinet/utils/dateUtils";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const AdminItemProvideTable = ({
   itemLog,
@@ -20,7 +20,7 @@ const AdminItemProvideTable = ({
             <th>아이템</th>
           </tr>
         </TheadStyled>
-        {itemLog !== STATUS_400_BAD_REQUEST && (
+        {itemLog !== HttpStatusCode.BadRequest && (
           <TbodyStyled>
             {itemLog.itemHistories.map(
               ({ issuedDate, itemName, itemDetails, usedAt }, idx) => (
@@ -47,7 +47,7 @@ const AdminItemProvideTable = ({
           </TbodyStyled>
         )}
       </LogTableStyled>
-      {itemLog === STATUS_400_BAD_REQUEST && (
+      {itemLog === HttpStatusCode.BadRequest && (
         <EmptyLogStyled>아이템 사용기록이 없습니다.</EmptyLogStyled>
       )}
     </LogTableWrapperstyled>

--- a/frontend/src/Cabinet/components/LentLog/AdminCabinetLentLog.container.tsx
+++ b/frontend/src/Cabinet/components/LentLog/AdminCabinetLentLog.container.tsx
@@ -1,3 +1,4 @@
+import { HttpStatusCode } from "axios";
 import { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { currentCabinetIdState } from "@/Cabinet/recoil/atoms";
@@ -5,7 +6,6 @@ import AdminCabinetLentLog from "@/Cabinet/components/LentLog/AdminCabinetLentLo
 import { LentLogResponseType } from "@/Cabinet/types/dto/lent.dto";
 import { axiosGetCabinetLentLog } from "@/Cabinet/api/axios/axios.custom";
 import useMenu from "@/Cabinet/hooks/useMenu";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const AdminCabinetLentLogContainer = () => {
   const { closeLent } = useMenu();
@@ -20,7 +20,7 @@ const AdminCabinetLentLogContainer = () => {
       setTotalPage(Math.ceil(result.data.totalLength / 10));
       setLogs(result.data.result);
     } catch {
-      setLogs(STATUS_400_BAD_REQUEST);
+      setLogs(HttpStatusCode.BadRequest);
       setTotalPage(1);
     }
   }

--- a/frontend/src/Cabinet/components/LentLog/AdminUserLentLog.container.tsx
+++ b/frontend/src/Cabinet/components/LentLog/AdminUserLentLog.container.tsx
@@ -1,3 +1,4 @@
+import { HttpStatusCode } from "axios";
 import { useEffect, useState } from "react";
 import { useRecoilValue } from "recoil";
 import { targetUserInfoState } from "@/Cabinet/recoil/atoms";
@@ -5,7 +6,6 @@ import AdminUserLentLog from "@/Cabinet/components/LentLog/AdminUserLentLog";
 import { LentLogResponseType } from "@/Cabinet/types/dto/lent.dto";
 import { axiosGetUserLentLog } from "@/Cabinet/api/axios/axios.custom";
 import useMenu from "@/Cabinet/hooks/useMenu";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const AdminUserLentLogContainer = () => {
   const { closeLent } = useMenu();
@@ -20,7 +20,7 @@ const AdminUserLentLogContainer = () => {
       setTotalPage(Math.ceil(result.data.totalLength / 10));
       setLogs(result.data.result);
     } catch {
-      setLogs(STATUS_400_BAD_REQUEST);
+      setLogs(HttpStatusCode.BadRequest);
       setTotalPage(1);
     }
   }

--- a/frontend/src/Cabinet/components/LentLog/LentLog.container.tsx
+++ b/frontend/src/Cabinet/components/LentLog/LentLog.container.tsx
@@ -1,10 +1,10 @@
+import { HttpStatusCode } from "axios";
 import { useEffect, useState } from "react";
 import LentLog from "@/Cabinet/components/LentLog/LentLog";
 import { LentLogResponseType } from "@/Cabinet/types/dto/lent.dto";
 import { axiosMyLentLog } from "@/Cabinet/api/axios/axios.custom";
 import useMenu from "@/Cabinet/hooks/useMenu";
 import { getTotalPage } from "@/Cabinet/utils/paginationUtils";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const LentLogContainer = () => {
   const { closeLent } = useMenu();
@@ -17,7 +17,7 @@ const LentLogContainer = () => {
       setTotalPage(getTotalPage(result.data.totalLength, 10));
       setLogs(result.data.result);
     } catch {
-      setLogs(STATUS_400_BAD_REQUEST);
+      setLogs(HttpStatusCode.BadRequest);
     }
   }
   useEffect(() => {

--- a/frontend/src/Cabinet/components/LentLog/LogTable/AdminCabinetLogTable.tsx
+++ b/frontend/src/Cabinet/components/LentLog/LogTable/AdminCabinetLogTable.tsx
@@ -1,8 +1,8 @@
+import { HttpStatusCode } from "axios";
 import styled from "styled-components";
 import LoadingAnimation from "@/Cabinet/components/Common/LoadingAnimation";
 import { LentLogResponseType } from "@/Cabinet/types/dto/lent.dto";
 import { formatDate } from "@/Cabinet/utils/dateUtils";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const AdminCabinetLogTable = ({
   lentLog,
@@ -21,7 +21,7 @@ const AdminCabinetLogTable = ({
             <th>반납일</th>
           </tr>
         </TheadStyled>
-        {lentLog !== STATUS_400_BAD_REQUEST && (
+        {lentLog !== HttpStatusCode.BadRequest && (
           <TbodyStyled>
             {lentLog.map(
               ({ floor, section, name, startedAt, endedAt }, idx) => (
@@ -45,7 +45,7 @@ const AdminCabinetLogTable = ({
           </TbodyStyled>
         )}
       </LogTableStyled>
-      {(lentLog === STATUS_400_BAD_REQUEST || lentLog.length === 0) && (
+      {(lentLog === HttpStatusCode.BadRequest || lentLog.length === 0) && (
         <EmptyLogStyled>대여기록이 없습니다.</EmptyLogStyled>
       )}
     </LogTableWrapperstyled>

--- a/frontend/src/Cabinet/components/LentLog/LogTable/LogTable.tsx
+++ b/frontend/src/Cabinet/components/LentLog/LogTable/LogTable.tsx
@@ -1,8 +1,8 @@
+import { HttpStatusCode } from "axios";
 import styled from "styled-components";
 import LoadingAnimation from "@/Cabinet/components/Common/LoadingAnimation";
 import { LentLogResponseType } from "@/Cabinet/types/dto/lent.dto";
 import { formatDate } from "@/Cabinet/utils/dateUtils";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const LogTable = ({ lentHistory }: { lentHistory: LentLogResponseType }) => {
   if (lentHistory === undefined) return <LoadingAnimation />;
@@ -17,7 +17,7 @@ const LogTable = ({ lentHistory }: { lentHistory: LentLogResponseType }) => {
             <th>반납일</th>
           </tr>
         </TheadStyled>
-        {lentHistory !== STATUS_400_BAD_REQUEST && (
+        {lentHistory !== HttpStatusCode.BadRequest && (
           <TbodyStyled>
             {lentHistory.map(
               ({ floor, section, visibleNum, startedAt, endedAt }, idx) => (
@@ -43,7 +43,7 @@ const LogTable = ({ lentHistory }: { lentHistory: LentLogResponseType }) => {
           </TbodyStyled>
         )}
       </LogTableStyled>
-      {lentHistory === STATUS_400_BAD_REQUEST ||
+      {lentHistory === HttpStatusCode.BadRequest ||
         (lentHistory.length === 0 && (
           <EmptyLogStyled>대여기록이 없습니다.</EmptyLogStyled>
         ))}

--- a/frontend/src/Cabinet/components/Modals/StoreModal/SwapModal.tsx
+++ b/frontend/src/Cabinet/components/Modals/StoreModal/SwapModal.tsx
@@ -74,7 +74,7 @@ const SwapModal: React.FC<{
       }
     } catch (error: any) {
       setModalTitle("이사권 사용실패");
-      if (error.response.ststus === 400) {
+      if (error.response.status === 400) {
         setModalContent(
           "현재 이사권을 보유하고 있지 않습니다.\n이사권은 까비상점에서 구매하실 수 있습니다."
         );

--- a/frontend/src/Cabinet/components/Modals/StoreModal/SwapModal.tsx
+++ b/frontend/src/Cabinet/components/Modals/StoreModal/SwapModal.tsx
@@ -16,10 +16,10 @@ import {
 import { modalPropsMap } from "@/Cabinet/assets/data/maps";
 import { MyCabinetInfoResponseDto } from "@/Cabinet/types/dto/cabinet.dto";
 import IconType from "@/Cabinet/types/enum/icon.type.enum";
-import { axiosUseItem } from "@/Cabinet/api/axios/axios.custom";
 import {
   axiosCabinetById,
   axiosMyLentInfo,
+  axiosUseItem,
 } from "@/Cabinet/api/axios/axios.custom";
 
 const SwapModal: React.FC<{

--- a/frontend/src/Cabinet/components/Store/StoreCoinPick.tsx
+++ b/frontend/src/Cabinet/components/Store/StoreCoinPick.tsx
@@ -14,7 +14,9 @@ const StoreCoinPick = () => {
       height={"320px"}
     >
       <>
-        <CoinAnimation />
+        <CoinAnimationStyled>
+          <CoinAnimation />
+        </CoinAnimationStyled>
         <CoinSummary>
           <p>누군가가 매일 흘리는 동전을 주워보세요💰</p>
           <p>동전은 하루에 한 번씩 주울 수 있습니다</p>
@@ -26,6 +28,11 @@ const StoreCoinPick = () => {
     </Card>
   );
 };
+
+const CoinAnimationStyled = styled.div`
+  min-width: 140px;
+  min-height: 140px;
+`;
 
 const CoinSummary = styled.div`
   background-color: var(--card-content-bg-color);

--- a/frontend/src/Cabinet/constants/StatusCode.ts
+++ b/frontend/src/Cabinet/constants/StatusCode.ts
@@ -1,2 +1,1 @@
-export const STATUS_400_BAD_REQUEST = 400;
 export const STATUS_401_UNAUTHORIZED = 401;

--- a/frontend/src/Cabinet/constants/StatusCode.ts
+++ b/frontend/src/Cabinet/constants/StatusCode.ts
@@ -1,1 +1,0 @@
-export const STATUS_401_UNAUTHORIZED = 401;

--- a/frontend/src/Cabinet/hooks/useClubInfo.ts
+++ b/frontend/src/Cabinet/hooks/useClubInfo.ts
@@ -1,3 +1,4 @@
+import { HttpStatusCode } from "axios";
 import { useEffect, useRef, useState } from "react";
 import { useRecoilState, useSetRecoilState } from "recoil";
 import {
@@ -11,7 +12,6 @@ import {
 } from "@/Cabinet/types/dto/club.dto";
 import { axiosGetClubInfo } from "@/Cabinet/api/axios/axios.custom";
 import useMenu from "@/Cabinet/hooks/useMenu";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const useClubInfo = () => {
   const [clubState, setClubState] = useState({ clubId: 0, page: 0 });
@@ -54,7 +54,7 @@ const useClubInfo = () => {
       }, 500);
     } catch {
       setTimeout(() => {
-        setClubInfo(STATUS_400_BAD_REQUEST);
+        setClubInfo(HttpStatusCode.BadRequest);
       }, 500);
     }
   };

--- a/frontend/src/Cabinet/hooks/useMenu.ts
+++ b/frontend/src/Cabinet/hooks/useMenu.ts
@@ -200,7 +200,9 @@ const useMenu = () => {
   };
 
   const closeUserStore = () => {
-    if (document.getElementById("itemInfo")?.classList.contains("on") == true) {
+    if (
+      document.getElementById("itemInfo")?.classList.contains("on") === true
+    ) {
       document.getElementById("itemInfo")?.classList.remove("on");
     }
   };

--- a/frontend/src/Cabinet/pages/LogPage.tsx
+++ b/frontend/src/Cabinet/pages/LogPage.tsx
@@ -1,10 +1,10 @@
+import { HttpStatusCode } from "axios";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 import LogTable from "@/Cabinet/components/LentLog/LogTable/LogTable";
 import { LentHistoryDto } from "@/Cabinet/types/dto/lent.dto";
 import { LentLogResponseType } from "@/Cabinet/types/dto/lent.dto";
 import { axiosMyLentLog } from "@/Cabinet/api/axios/axios.custom";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 
 const LogPage = () => {
   const [lentLog, setLentLog] = useState<LentLogResponseType>(undefined);
@@ -18,7 +18,7 @@ const LogPage = () => {
       }, 500);
     } catch {
       setTimeout(() => {
-        setLentLog(STATUS_400_BAD_REQUEST);
+        setLentLog(HttpStatusCode.BadRequest);
       }, 500);
     }
   };

--- a/frontend/src/Cabinet/types/dto/admin.dto.ts
+++ b/frontend/src/Cabinet/types/dto/admin.dto.ts
@@ -1,4 +1,4 @@
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
+import { HttpStatusCode } from "axios";
 
 export interface BannedUserDto {
   userId: number;
@@ -78,7 +78,7 @@ export interface ItemLogResponse {
 
 export type ItemLogResponseType =
   | ItemLogResponse
-  | typeof STATUS_400_BAD_REQUEST
+  | HttpStatusCode.BadRequest
   | undefined;
 
 export interface IItemUseCountDto {

--- a/frontend/src/Cabinet/types/dto/club.dto.ts
+++ b/frontend/src/Cabinet/types/dto/club.dto.ts
@@ -1,8 +1,8 @@
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
+import { HttpStatusCode } from "axios";
 
 export type ClubListReponseType =
   | ClubPaginationResponseDto
-  | typeof STATUS_400_BAD_REQUEST
+  | HttpStatusCode.BadRequest
   | undefined;
 
 export interface ClubPaginationResponseDto {
@@ -18,7 +18,7 @@ export interface ClubResponseDto {
 
 export type ClubInfoResponseType =
   | ClubInfoResponseDto
-  | typeof STATUS_400_BAD_REQUEST
+  | HttpStatusCode.BadRequest
   | undefined;
 
 export interface ClubCabinetInfo {

--- a/frontend/src/Cabinet/types/dto/lent.dto.ts
+++ b/frontend/src/Cabinet/types/dto/lent.dto.ts
@@ -1,4 +1,4 @@
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
+import { HttpStatusCode } from "axios";
 
 /**
  * @interface
@@ -31,7 +31,7 @@ export interface LentHistoryDto {
 
 export type LentLogResponseType =
   | LentHistoryDto[]
-  | typeof STATUS_400_BAD_REQUEST
+  | HttpStatusCode.BadRequest
   | undefined;
 
 export interface ILentLog {
@@ -51,7 +51,7 @@ export interface ClubUserDto {
 
 export type ClubLogResponseType =
   | ClubUserDto[]
-  | typeof STATUS_400_BAD_REQUEST
+  | HttpStatusCode.BadRequest
   | undefined;
 
 export interface IClubLog {

--- a/frontend/src/Cabinet/types/enum/error.type.enum.ts
+++ b/frontend/src/Cabinet/types/enum/error.type.enum.ts
@@ -2,6 +2,7 @@ enum ErrorType {
   LENT = "LENT",
   RETURN = "RETURN",
   STORE = "STORE",
+  INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR",
 }
 
 export default ErrorType;

--- a/frontend/src/Cabinet/types/enum/error.type.enum.ts
+++ b/frontend/src/Cabinet/types/enum/error.type.enum.ts
@@ -1,0 +1,7 @@
+enum ErrorType {
+  LENT = "LENT",
+  RETURN = "RETURN",
+  STORE = "STORE",
+}
+
+export default ErrorType;

--- a/frontend/src/Presentation/components/PresentationLog/LogTable.tsx
+++ b/frontend/src/Presentation/components/PresentationLog/LogTable.tsx
@@ -1,7 +1,7 @@
+import { HttpStatusCode } from "axios";
 import styled from "styled-components";
 import LoadingAnimation from "@/Cabinet/components/Common/LoadingAnimation";
 import { formatDate } from "@/Cabinet/utils/dateUtils";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 import {
   PresentationLocationLabelMap,
   PresentationStatusTypeLabelMap,
@@ -26,7 +26,7 @@ const LogTable = ({
             <th>상태</th>
           </tr>
         </TheadStyled>
-        {presentationHistory !== STATUS_400_BAD_REQUEST && (
+        {presentationHistory !== HttpStatusCode.BadRequest && (
           <TbodyStyled>
             {presentationHistory.map(
               (
@@ -50,7 +50,7 @@ const LogTable = ({
           </TbodyStyled>
         )}
       </LogTableStyled>
-      {presentationHistory === STATUS_400_BAD_REQUEST ||
+      {presentationHistory === HttpStatusCode.BadRequest ||
         (presentationHistory.length === 0 && (
           <EmptyLogStyled>발표기록이 없습니다.</EmptyLogStyled>
         ))}

--- a/frontend/src/Presentation/pages/LogPage.tsx
+++ b/frontend/src/Presentation/pages/LogPage.tsx
@@ -1,6 +1,6 @@
+import { HttpStatusCode } from "axios";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
 import LogTable from "@/Presentation/components/PresentationLog/LogTable";
 import {
   PresentationHistoryDto,
@@ -21,7 +21,7 @@ const PresentationLogPage = () => {
       }, 500);
     } catch {
       setTimeout(() => {
-        setPresentationLog(STATUS_400_BAD_REQUEST);
+        setPresentationLog(HttpStatusCode.BadRequest);
       }, 500);
     }
   };

--- a/frontend/src/Presentation/types/dto/presentation.dto.ts
+++ b/frontend/src/Presentation/types/dto/presentation.dto.ts
@@ -1,4 +1,4 @@
-import { STATUS_400_BAD_REQUEST } from "@/Cabinet/constants/StatusCode";
+import { HttpStatusCode } from "axios";
 import {
   PresentationCategoryType,
   PresentationLocation,
@@ -18,7 +18,7 @@ export interface PresentationHistoryDto {
 
 export type PresentationHistoryResponseType =
   | PresentationHistoryDto[]
-  | typeof STATUS_400_BAD_REQUEST
+  | HttpStatusCode.BadRequest
   | undefined;
 
 export interface IPresentationInfo {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,17 +1,56 @@
+import App from "@/App";
+import "@/index.css";
+import * as Sentry from "@sentry/react";
+import { useEffect } from "react";
 import React from "react";
 import ReactDOM from "react-dom/client";
+import {
+  createRoutesFromChildren,
+  matchRoutes,
+  useLocation,
+  useNavigationType,
+} from "react-router-dom";
 import { RecoilRoot } from "recoil";
+import "@/Cabinet/assets/css/media.css";
+import "@/Cabinet/assets/css/reset.css";
 import { GlobalStyle } from "@/Cabinet/assets/data/ColorTheme";
-import App from "./App";
-import "./Cabinet/assets/css/media.css";
-import "./Cabinet/assets/css/reset.css";
-import "./index.css";
+
+Sentry.init({
+  dsn: "https://5e0e8ad22001254b0aabd23f79be09a4@o4507625901981696.ingest.us.sentry.io/4507625903489024",
+  environment: "development",
+  release: "^8.18.0",
+  integrations: [
+    // See docs for support of different versions of variation of react router
+    // https://docs.sentry.io/platforms/javascript/guides/react/configuration/integrations/react-router/
+    Sentry.reactRouterV6BrowserTracingIntegration({
+      useEffect,
+      useLocation,
+      useNavigationType,
+      createRoutesFromChildren,
+      matchRoutes,
+    }),
+    Sentry.replayIntegration(),
+  ],
+
+  // Set tracesSampleRate to 1.0 to capture 100%
+  // of transactions for tracing.
+  tracesSampleRate: 1.0,
+
+  // Set `tracePropagationTargets` to control for which URLs trace propagation should be enabled
+  // tracePropagationTargets: [/^\//, /^https:\/\/yourserver\.io\/api/],
+  tracePropagationTargets: ["localhost", /^https:\/\/api\.cabi\.42seoul\.io/],
+
+  // Capture Replay for 100% of all sessions,
+  // plus for 100% of sessions with an error
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 1.0,
+});
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  // <React.StrictMode>
-  <RecoilRoot>
-    <GlobalStyle />
-    <App />
-  </RecoilRoot>
-  // </React.StrictMode>
+  <React.StrictMode>
+    <RecoilRoot>
+      <GlobalStyle />
+      <App />
+    </RecoilRoot>
+  </React.StrictMode>
 );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -38,7 +38,11 @@ Sentry.init({
 
   // Set `tracePropagationTargets` to control for which URLs trace propagation should be enabled
   // tracePropagationTargets: [/^\//, /^https:\/\/yourserver\.io\/api/],
-  tracePropagationTargets: ["localhost", /^https:\/\/api\.cabi\.42seoul\.io/],
+  tracePropagationTargets: [
+    "localhost",
+    /^https:\/\/api\.cabi\.42seoul\.io/,
+    /^https:\/\/api-dev\.cabi\.42seoul\.io/,
+  ],
 
   // Capture Replay for 100% of all sessions,
   // plus for 100% of sessions with an error

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,8 +1,5 @@
-import App from "@/App";
-import "@/index.css";
 import * as Sentry from "@sentry/react";
-import { useEffect } from "react";
-import React from "react";
+import React, { useEffect } from "react";
 import ReactDOM from "react-dom/client";
 import {
   createRoutesFromChildren,
@@ -13,6 +10,8 @@ import {
 import { RecoilRoot } from "recoil";
 import "@/Cabinet/assets/css/media.css";
 import "@/Cabinet/assets/css/reset.css";
+import "@/index.css";
+import App from "@/App";
 import { GlobalStyle } from "@/Cabinet/assets/data/ColorTheme";
 
 Sentry.init({

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -15,7 +15,7 @@ import App from "@/App";
 import { GlobalStyle } from "@/Cabinet/assets/data/ColorTheme";
 
 Sentry.init({
-  dsn: "https://5e0e8ad22001254b0aabd23f79be09a4@o4507625901981696.ingest.us.sentry.io/4507625903489024",
+  dsn: import.meta.env.VITE_SENTRY_DSN,
   environment: "development",
   release: "^8.18.0",
   integrations: [

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -16,7 +16,8 @@ import { GlobalStyle } from "@/Cabinet/assets/data/ColorTheme";
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
-  environment: "development",
+  environment:
+    import.meta.env.VITE_IS_LOCAL === "true" ? "local" : "production",
   release: "^8.18.0",
   integrations: [
     // See docs for support of different versions of variation of react router

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,19 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    react(),
+    react({
+      babel: {
+        plugins: [
+          [
+            "babel-plugin-styled-components",
+            {
+              displayName: true,
+              fileName: false,
+            },
+          ],
+        ],
+      },
+    }),
     visualizer({ open: true, gzipSize: true, template: "treemap" }),
     svgr(),
   ],


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

### Sentry 

- 프런트엔드에서 발생하는 예상치 못한 에러와 핵심 비즈니스 로직에서 생기는 에러를 추적하고자 Sentry 를 도입하였습니다.

- 센트리로 전송하는 이슈 종류 : 500에러, 대여 • 반납 • 재화 에러
    - ErrorType 정의
        ```tsx
        enum ErrorType {
          LENT = "LENT",
          RETURN = "RETURN",
          STORE = "STORE",
          INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR",
        }
        ```
        
    - 500 에러
        `axios.instance.ts` 에러 핸들링 파트에 아래 코드 추가
        
        ```jsx
        else if (error.response?.status === HttpStatusCode.InternalServerError) {
          logAxiosError(error, ErrorType.INTERNAL_SERVER_ERROR, "서버 에러");
        }
        ```
        
    - 대여 • 반납 • 재화
        `axios.custom.ts`의 에러 핸들링 파트에 아래 코드 추가
        ```jsx
        logAxiosError(
          error,
          ErrorType.STORE,
          "동전 줍기 정보 불러오는 중 오류 발생"
        );
        ```

- 디스코드와 연동해서 발생 이슈에 대한 내용을 **sentry_test** 채널에 알림 전송

   <img src="https://github.com/user-attachments/assets/416921ea-83d5-4624-b701-e4bb371ada14" width="400" >

    
- logAxiosError -  `센트리 홈페이지 - issues`에서 이슈 파악을 수월하게 하고, `tags` 사용해 디스코드 알림 내용 구성
  ```jsx
  export const logAxiosError = (
    error: any,
    type: ErrorType,
    errorMsg: string,
    isAdmin = false
  ) => {
    error.message = (isAdmin ? "[Admin] " : "") + errorMsg;
    captureException(error, {
      tags: {
        userId: userId,
        api: error.response?.config.url,
        httpMethod: error.config?.method?.toUpperCase(),
        httpStatusCode: (error.response?.status ?? "").toString(),
      },
      level: "error",
      extra: { type: type },
    });
  };
  ```
  - 이슈가 어드민 페이지에서 발생하는지 여부에 따라 `error.message` 의 구성 달라짐
  - userId - `admin_access_token`의 사용자 아이디
  - level 확인
    <img src="https://github.com/user-attachments/assets/65273905-26a6-4963-bf2e-f47aa419f01a" width="300">
  - type 확인
      <img src="https://github.com/user-attachments/assets/188225c0-0af1-4b97-938e-d43661a01d8c" width="300">

- `tracesSampleRate`
  : 발생되는 이슈들 중 센트리로 보고되는 대표적인 이슈 샘플 비율
  일단 기본값인 `1`로 설정하고 2주 정도 경과 보고, 조정 필요시 조정하고 **프론트_모니터링** 채널에 연결

### babel-plugin-styled-components

<img width="600" alt="image" src="https://github.com/user-attachments/assets/75f9279a-cfdb-40b1-bacb-0b5b9388f582">

- Sentry 에서 Breadcrumbs 참고 시 styled-components 특성 상 위 이미지처럼 명확하지 않은 className 으로 표시되어 이를 개선하고, 브라우저 DOM 에서의 가독성도 높이고자 `babel-plugin-styled-components` 를 추가하고, vite.config.ts 에 이를 추가하였습니다.
- Styled-components 의 className 앞에 변수명이 추가되어, 새로운 Breadcrumbs는 아래와 같습니다. 
<img width="600" alt="image" src="https://github.com/user-attachments/assets/941f7863-89da-46cf-9c70-f1c785b7fb39">


https://github.com/innovationacademy-kr/42cabi/issues/1665
