### PR TITLE
[BE] FIX: User BlackholedAt 갱신 로직 추가 & 42API 로그인 이후 블랙홀이 DB와 불일치할 경우 …

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/auth/service/AuthFacadeService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/auth/service/AuthFacadeService.java
@@ -81,6 +81,10 @@ public class AuthFacadeService {
 		FtProfile profile = userOauthService.getProfileByCode(code);
 		User user = userQueryService.findUser(profile.getIntraName())
 				.orElseGet(() -> userCommandService.createUserByFtProfile(profile));
+		// 블랙홀이 API에서 가져온 날짜와 다르다면 갱신
+		if (!user.isSameBlackholedAt(profile.getBlackHoledAt())) {
+			userCommandService.updateUserBlackholedAtById(user.getId(), profile.getBlackHoledAt());
+		}
 		String token = tokenProvider.createUserToken(user, LocalDateTime.now());
 		Cookie cookie = cookieManager.cookieOf(TokenProvider.USER_TOKEN_NAME, token);
 		cookieManager.setCookieToClient(res, cookie, "/", req.getServerName());

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
@@ -148,9 +148,20 @@ public class User {
 		return blackholedAt != null && blackholedAt.isBefore(LocalDateTime.now());
 	}
 
+	/**
+	 * this.blackholedAt과 전달인자 blackholedAt 중 어느 하나가 null인 경우 false를 반환
+	 *
+	 * @param blackholedAt
+	 * @return
+	 */
 	public boolean isSameBlackholedAt(LocalDateTime blackholedAt) {
+		if (this.blackholedAt == null || blackholedAt == null) {
+			return this.blackholedAt == null && blackholedAt == null;
+		}
+
 		return this.blackholedAt.isEqual(blackholedAt);
 	}
+
 
 	public void addCoin(Long reward) {
 		this.coin += reward;

--- a/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/domain/User.java
@@ -148,6 +148,10 @@ public class User {
 		return blackholedAt != null && blackholedAt.isBefore(LocalDateTime.now());
 	}
 
+	public boolean isSameBlackholedAt(LocalDateTime blackholedAt) {
+		return this.blackholedAt.isEqual(blackholedAt);
+	}
+
 	public void addCoin(Long reward) {
 		this.coin += reward;
 	}

--- a/backend/src/main/java/org/ftclub/cabinet/user/repository/UserRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/user/repository/UserRepository.java
@@ -46,7 +46,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	 * @param name 유저 이름
 	 * @return {@link User}
 	 */
-	@Query("SELECT u FROM User u WHERE u.name = :name AND u.deletedAt IS NULL")
+	@Query("SELECT u FROM User u WHERE u.name = :name")
 	Optional<User> findByName(@Param("name") String name);
 
 	/**

--- a/backend/src/test/java/org/ftclub/cabinet/user/domain/UserTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/user/domain/UserTest.java
@@ -1,9 +1,34 @@
 package org.ftclub.cabinet.user.domain;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 @RequiredArgsConstructor
 public class UserTest {
+
+	@Test
+	void isSameBlackholedAt_test_both_null() {
+		User test = User.of("test", "aewf@naver.com", null);
+		boolean sameBlackholedAt = test.isSameBlackholedAt(null);
+		Assertions.assertTrue(sameBlackholedAt);
+	}
+
+	@Test
+	void isSameBlackholedAt_test_one_null() {
+		User test = User.of("test", "aewf@naver.com", null);
+		boolean sameBlackholedAt = test.isSameBlackholedAt(LocalDateTime.now());
+		Assertions.assertFalse(sameBlackholedAt);
+	}
+
+	@Test
+	void isSameBlackholedAt_test_same() {
+		LocalDateTime now = LocalDateTime.now();
+		User test = User.of("test", "aewf@naver.com", now);
+		boolean sameBlackholedAt = test.isSameBlackholedAt(now);
+		Assertions.assertTrue(sameBlackholedAt);
+	}
 
 //	@Test
 //	@DisplayName("유저 생성 성공 - 일반적인 이메일 형식")


### PR DESCRIPTION
- 로그인 로직 수정
42API 로그인 이후 /callback 으로 요청이 온 경우, 이미 42API 에서 로그인을 허가 해준 경우 이므로, AGU 혹은 블랙홀 유저일 수 없다.
따라서 42API 조회 정보에서 조회한 BlackholedAt과, Cabi DB의 해당 유저 BlackholedAt 이 다르다면, 갱신하도록 갱신 로직을 추가
- 위와 같은 이유로 로그인해서 찾아오는 UserRepository의 findUser 로직에서 blackholed_at IS NULL 을 제거

<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/
