### PR TITLE
[FE] BUG: 모달에서 링크로 이동 시 모든 창을 닫도록 closeAll 추가 #1668

### DIFF
--- a/frontend/src/Cabinet/components/Modals/Modal.tsx
+++ b/frontend/src/Cabinet/components/Modals/Modal.tsx
@@ -6,6 +6,7 @@ import Button from "@/Cabinet/components/Common/Button";
 import { ReactComponent as CheckIcon } from "@/Cabinet/assets/images/checkIcon.svg";
 import { ReactComponent as ErrorIcon } from "@/Cabinet/assets/images/errorIcon.svg";
 import { ReactComponent as NotificationIcon } from "@/Cabinet/assets/images/notificationSign.svg";
+import useMenu from "@/Cabinet/hooks/useMenu";
 import useMultiSelect from "@/Cabinet/hooks/useMultiSelect";
 
 /**
@@ -63,6 +64,7 @@ const Modal: React.FC<{ modalContents: IModalContents }> = (props) => {
   } = props.modalContents;
   const { isMultiSelect, closeMultiSelectMode } = useMultiSelect();
   const navigator = useNavigate();
+  const { closeAll } = useMenu();
 
   return (
     <>
@@ -127,6 +129,7 @@ const Modal: React.FC<{ modalContents: IModalContents }> = (props) => {
         {url && urlTitle && (
           <UrlSectionStyled
             onClick={() => {
+              closeAll();
               navigator(url);
             }}
           >


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
### 문제
- 이사권 사용실패 모달창에서 링크를 클릭해 까비상점으로 이동 시, 1040px 이하에서 상점으로 이동 후 Menu Background 가 해제되지 않음
### 해결
- 모달 내 링크로 다른 Route 이동 시, `closeAll()` 로 Menu Background 해제

https://github.com/innovationacademy-kr/42cabi/issues/1668
