### PR TITLE
[FE] FIX: 홈 페이지 상세보기 버튼 클릭시 열리는 창 url 변경 #1697

### DIFF
--- a/frontend/src/Cabinet/assets/images/link.svg
+++ b/frontend/src/Cabinet/assets/images/link.svg
@@ -1,5 +1,4 @@
 <svg width="15" height="15" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-<!-- <svg width="100%" height="100%" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"> -->
 <path d="M6.5 5.50039L10.6 1.40039" stroke="current" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M10.9996 3.4V1H8.59961" stroke="current" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M5.5 1H4.5C2 1 1 2 1 4.5V7.5C1 10 2 11 4.5 11H7.5C10 11 11 10 11 7.5V6.5" stroke="current" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round"/>

--- a/frontend/src/Cabinet/assets/images/link.svg
+++ b/frontend/src/Cabinet/assets/images/link.svg
@@ -1,4 +1,5 @@
 <svg width="15" height="15" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<!-- <svg width="100%" height="100%" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg"> -->
 <path d="M6.5 5.50039L10.6 1.40039" stroke="current" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M10.9996 3.4V1H8.59961" stroke="current" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M5.5 1H4.5C2 1 1 2 1 4.5V7.5C1 10 2 11 4.5 11H7.5C10 11 11 10 11 7.5V6.5" stroke="current" stroke-width="0.75" stroke-linecap="round" stroke-linejoin="round"/>

--- a/frontend/src/Cabinet/components/Home/ServiceManual.tsx
+++ b/frontend/src/Cabinet/components/Home/ServiceManual.tsx
@@ -20,7 +20,7 @@ const ServiceManual = ({
   };
 
   const openNotionLink = () => {
-    window.open("https://cabi.oopy.io/0bbb08a2-241c-444b-8a96-6b33c3796451");
+    window.open("https://cabi.oopy.io/115f29ec-ef8e-4748-a8a6-0d0341def33c");
   };
 
   return (

--- a/frontend/src/Cabinet/components/Home/ServiceManual.tsx
+++ b/frontend/src/Cabinet/components/Home/ServiceManual.tsx
@@ -31,8 +31,7 @@ const ServiceManual = ({
           Cabi <span>이용 안내서</span>
         </h1>
         <NotionBtn className="button" onClick={openNotionLink}>
-          상세보기
-          {/* <span>상세보기</span> */}
+          <span>상세보기</span>
           <LinkImg id="linknImg" stroke="var(--notion-btn-text-color)" />
         </NotionBtn>
       </TitleContainerStyled>
@@ -151,9 +150,9 @@ const NotionBtn = styled.button`
   color: var(--notion-btn-text-color);
   background: var(--bg-color);
   border: 1px solid var(--line-color);
-  /* display: flex;
+  display: flex;
   align-items: center;
-  justify-content: center; */
+  justify-content: center;
   @media (hover: hover) and (pointer: fine) {
     &:hover {
       color: var(--normal-text-color);
@@ -166,10 +165,10 @@ const NotionBtn = styled.button`
     }
   }
 
-  /* & > span {
+  & > span {
     line-height: 14px;
     height: 16px;
-  } */
+  }
 
   & > #linknImg {
     width: 12px;

--- a/frontend/src/Cabinet/components/Home/ServiceManual.tsx
+++ b/frontend/src/Cabinet/components/Home/ServiceManual.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import styled from "styled-components";
 import ManualContentBox from "@/Cabinet/components/Home/ManualContentBox";
 import ManualModal from "@/Cabinet/components/Modals/ManualModal/ManualModal";
+import { ReactComponent as LinkImg } from "@/Cabinet/assets/images/link.svg";
 import ContentStatus from "@/Cabinet/types/enum/content.status.enum";
 
 const ServiceManual = ({
@@ -31,6 +32,8 @@ const ServiceManual = ({
         </h1>
         <NotionBtn className="button" onClick={openNotionLink}>
           상세보기
+          {/* <span>상세보기</span> */}
+          <LinkImg id="linknImg" stroke="var(--notion-btn-text-color)" />
         </NotionBtn>
       </TitleContainerStyled>
 
@@ -148,9 +151,30 @@ const NotionBtn = styled.button`
   color: var(--notion-btn-text-color);
   background: var(--bg-color);
   border: 1px solid var(--line-color);
-  :hover {
-    color: var(--normal-text-color);
-    font-weight: 400;
+  /* display: flex;
+  align-items: center;
+  justify-content: center; */
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      color: var(--normal-text-color);
+      font-weight: 400;
+
+      #linknImg > path {
+        stroke: var(--normal-text-color);
+        stroke-width: 1.2px;
+      }
+    }
+  }
+
+  /* & > span {
+    line-height: 14px;
+    height: 16px;
+  } */
+
+  & > #linknImg {
+    width: 12px;
+    height: 12px;
+    margin-left: 4px;
   }
 `;
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [x] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명

### 문제

홈페이지 `상세보기` 버튼 클릭시 예전 안내문([Cabi V5 패치노트](https://cabi.oopy.io/0bbb08a2-241c-444b-8a96-6b33c3796451))이 새 창으로 열립니다

### 해결
```
  const openNotionLink = () => {
    window.open("https://cabi.oopy.io/115f29ec-ef8e-4748-a8a6-0d0341def33c"); //
  };
```
[까비 상점 OPEN url](https://cabi.oopy.io/115f29ec-ef8e-4748-a8a6-0d0341def33c)로 변경

### + 상세보기 버튼 UI 변경

<img width="134" alt="Screenshot 2024-10-23 at 3 09 36 PM" src="https://github.com/user-attachments/assets/d7e3b3dc-8cda-48f9-a31b-eec6c35cf9a4">

상세보기 텍스트 오른쪽에 링크 아이콘을 넣어 새 창이 열릴것임을 사용자에게 미리 알려줍니다.


https://github.com/innovationacademy-kr/42cabi/issues/1697
