### PR TITLE
[FE] 4층 사물함 접근 제한 #1703

### DIFF
--- a/frontend/src/Cabinet/components/CabinetList/CabinetList.container.tsx
+++ b/frontend/src/Cabinet/components/CabinetList/CabinetList.container.tsx
@@ -51,7 +51,7 @@ const CabinetListContainer = ({
           />
         </div>
       )}
-      {currentFloorSectionNames.includes(currentSectionName) && (
+      {currentFloorSectionNames.includes(currentSectionName) && (currentFloor !== 4) && (
         <RealViewNotification colNum={colNum as number} />
       )}
       {(!isAdmin && currentFloor === 4) ? (

--- a/frontend/src/Cabinet/components/CabinetList/CabinetList.container.tsx
+++ b/frontend/src/Cabinet/components/CabinetList/CabinetList.container.tsx
@@ -54,7 +54,7 @@ const CabinetListContainer = ({
       {currentFloorSectionNames.includes(currentSectionName) && (
         <RealViewNotification colNum={colNum as number} />
       )}
-      {currentFloor === 4 ? (
+      {(!isAdmin && currentFloor === 4) ? (
         <EmptySection message={"4층은 현재 이용 불가입니다!"} />
       ) : (
         <>

--- a/frontend/src/Cabinet/components/CabinetList/CabinetList.container.tsx
+++ b/frontend/src/Cabinet/components/CabinetList/CabinetList.container.tsx
@@ -9,6 +9,7 @@ import {
   currentSectionCabinetState,
   currentSectionColNumState,
 } from "@/Cabinet/recoil/selectors";
+import { DISABLED_FLOOR } from "@/Cabinet/pages/AvailablePage";
 import CabinetList from "@/Cabinet/components/CabinetList/CabinetList";
 import EmptySection from "@/Cabinet/components/CabinetList/EmptySection/EmptySection";
 import RealViewNotification from "@/Cabinet/components/CabinetList/RealViewNotification/RealViewNotification";
@@ -51,11 +52,11 @@ const CabinetListContainer = ({
           />
         </div>
       )}
-      {currentFloorSectionNames.includes(currentSectionName) && (currentFloor !== 4) && (
+      {currentFloorSectionNames.includes(currentSectionName) && !(DISABLED_FLOOR.includes(currentFloor.toString())) && (
         <RealViewNotification colNum={colNum as number} />
       )}
-      {(!isAdmin && currentFloor === 4) ? (
-        <EmptySection message={"4층은 현재 이용 불가입니다!"} />
+      {(!isAdmin && DISABLED_FLOOR.includes(currentFloor.toString())) ? (
+        <EmptySection message={`${currentFloor}층은 현재 이용 불가입니다!`} />
       ) : (
         <>
           <CabinetList

--- a/frontend/src/Cabinet/components/CabinetList/CabinetList.container.tsx
+++ b/frontend/src/Cabinet/components/CabinetList/CabinetList.container.tsx
@@ -19,10 +19,11 @@ import useMultiSelect from "@/Cabinet/hooks/useMultiSelect";
 
 interface ICabinetListContainer {
   isAdmin: boolean;
+  currentFloor: number;
 }
 
 const CabinetListContainer = ({
-  isAdmin,
+  isAdmin, currentFloor
 }: ICabinetListContainer): JSX.Element => {
   const colNum = useRecoilValue(currentSectionColNumState);
   const currentSectionCabinets = useRecoilValue<CabinetPreviewInfo[]>(
@@ -53,14 +54,20 @@ const CabinetListContainer = ({
       {currentFloorSectionNames.includes(currentSectionName) && (
         <RealViewNotification colNum={colNum as number} />
       )}
-      <CabinetList
-        colNum={colNum as number}
-        cabinetInfo={currentSectionCabinets}
-        isAdmin={isAdmin}
-      />
-      {(currentSectionName === SectionType.elevator ||
-        currentSectionName === SectionType.stairs) && (
-        <EmptySection message={"여기엔 사물함이 없어요!"} />
+      {currentFloor === 4 ? (
+        <EmptySection message={"4층은 현재 이용 불가입니다!"} />
+      ) : (
+        <>
+          <CabinetList
+            colNum={colNum as number}
+            cabinetInfo={currentSectionCabinets}
+            isAdmin={isAdmin}
+          />
+          {(currentSectionName === SectionType.elevator ||
+            currentSectionName === SectionType.stairs) && (
+              <EmptySection message={"여기엔 사물함이 없어요!"} />
+            )}
+        </>
       )}
     </React.Fragment>
   );

--- a/frontend/src/Cabinet/components/LeftNav/LeftMainNav/LeftMainNav.tsx
+++ b/frontend/src/Cabinet/components/LeftNav/LeftMainNav/LeftMainNav.tsx
@@ -5,6 +5,7 @@ import { ReactComponent as ProfileImg } from "@/Cabinet/assets/images/profile-ci
 import { ReactComponent as SlackAlarmImg } from "@/Cabinet/assets/images/slack-alarm.svg";
 import { ReactComponent as SlackImg } from "@/Cabinet/assets/images/slack.svg";
 import { ReactComponent as StoreImg } from "@/Cabinet/assets/images/storeIconGray.svg";
+import { DISABLED_FLOOR } from "@/Cabinet/pages/AvailablePage";
 
 interface ILeftMainNav {
   pathname: string;
@@ -58,7 +59,7 @@ const LeftMainNav = ({
               </TopBtnStyled>
               {floors &&
                 floors.map((floor, index) =>
-                  !(!isAdmin && floor === 4) ? (
+                  !(!isAdmin && DISABLED_FLOOR.includes(floor.toString())) ? (
                     <TopBtnStyled
                       className={
                         pathname.includes("main") && floor === currentFloor

--- a/frontend/src/Cabinet/components/LeftNav/LeftMainNav/LeftMainNav.tsx
+++ b/frontend/src/Cabinet/components/LeftNav/LeftMainNav/LeftMainNav.tsx
@@ -57,8 +57,8 @@ const LeftMainNav = ({
                 Home
               </TopBtnStyled>
               {floors &&
-                floors.map((floor, index) => (
-                  floor !== 4 && (
+                floors.map((floor, index) =>
+                  !(!isAdmin && floor === 4) ? (
                     <TopBtnStyled
                       className={
                         pathname.includes("main") && floor === currentFloor
@@ -70,8 +70,8 @@ const LeftMainNav = ({
                     >
                       {floor + "층"}
                     </TopBtnStyled>
-                  )
-                ))}
+                  ) : null
+                )}
               <TopBtnStyled
                 className={
                   pathname.includes("available")

--- a/frontend/src/Cabinet/components/LeftNav/LeftMainNav/LeftMainNav.tsx
+++ b/frontend/src/Cabinet/components/LeftNav/LeftMainNav/LeftMainNav.tsx
@@ -58,17 +58,19 @@ const LeftMainNav = ({
               </TopBtnStyled>
               {floors &&
                 floors.map((floor, index) => (
-                  <TopBtnStyled
-                    className={
-                      pathname.includes("main") && floor === currentFloor
-                        ? "leftNavButtonActive cabiButton"
-                        : "cabiButton"
-                    }
-                    onClick={() => onClickFloorButton(floor)}
-                    key={index}
-                  >
-                    {floor + "층"}
-                  </TopBtnStyled>
+                  floor !== 4 && (
+                    <TopBtnStyled
+                      className={
+                        pathname.includes("main") && floor === currentFloor
+                          ? "leftNavButtonActive cabiButton"
+                          : "cabiButton"
+                      }
+                      onClick={() => onClickFloorButton(floor)}
+                      key={index}
+                    >
+                      {floor + "층"}
+                    </TopBtnStyled>
+                  )
                 ))}
               <TopBtnStyled
                 className={

--- a/frontend/src/Cabinet/components/LeftNav/LeftSectionNav/LeftSectionNav.tsx
+++ b/frontend/src/Cabinet/components/LeftNav/LeftSectionNav/LeftSectionNav.tsx
@@ -3,6 +3,7 @@ import { useRecoilValue } from "recoil";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
 import { currentSectionNameState, currentFloorNumberState } from "@/Cabinet/recoil/atoms";
+import { DISABLED_FLOOR } from "@/Cabinet/pages/AvailablePage";
 import { currentFloorSectionState } from "@/Cabinet/recoil/selectors";
 import CabinetColorTable from "@/Cabinet/components/LeftNav/CabinetColorTable/CabinetColorTable";
 import { clubSectionsData } from "@/Cabinet/assets/data/mapPositionData";
@@ -46,7 +47,7 @@ const LeftSectionNav = ({ closeLeftNav }: { closeLeftNav: () => void }) => {
             <IconWrapperStyled>
               {!isAdmin &&
                 !isClubSection &&
-                currentFloorNumber !== 4 &&
+                !DISABLED_FLOOR.includes(currentFloorNumber.toString()) &&
                 (section.alarmRegistered ? (
                   <FilledHeartIcon />
                 ) : (

--- a/frontend/src/Cabinet/components/LeftNav/LeftSectionNav/LeftSectionNav.tsx
+++ b/frontend/src/Cabinet/components/LeftNav/LeftSectionNav/LeftSectionNav.tsx
@@ -2,7 +2,7 @@ import { useLocation } from "react-router-dom";
 import { useRecoilValue } from "recoil";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
-import { currentSectionNameState } from "@/Cabinet/recoil/atoms";
+import { currentSectionNameState, currentFloorNumberState } from "@/Cabinet/recoil/atoms";
 import { currentFloorSectionState } from "@/Cabinet/recoil/selectors";
 import CabinetColorTable from "@/Cabinet/components/LeftNav/CabinetColorTable/CabinetColorTable";
 import { clubSectionsData } from "@/Cabinet/assets/data/mapPositionData";
@@ -17,6 +17,7 @@ const LeftSectionNav = ({ closeLeftNav }: { closeLeftNav: () => void }) => {
   const [currentFloorSection, setCurrentFloorSection] = useRecoilState<string>(
     currentSectionNameState
   );
+  const currentFloorNumber = useRecoilValue<number>(currentFloorNumberState);
   const { pathname } = useLocation();
   const isAdmin = pathname.includes("admin");
 
@@ -45,6 +46,7 @@ const LeftSectionNav = ({ closeLeftNav }: { closeLeftNav: () => void }) => {
             <IconWrapperStyled>
               {!isAdmin &&
                 !isClubSection &&
+                currentFloorNumber !== 4 &&
                 (section.alarmRegistered ? (
                   <FilledHeartIcon />
                 ) : (

--- a/frontend/src/Cabinet/components/MapInfo/MapFloorSelectOption/MapFloorSelectOption.tsx
+++ b/frontend/src/Cabinet/components/MapInfo/MapFloorSelectOption/MapFloorSelectOption.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { DISABLED_FLOOR } from "@/Cabinet/pages/AvailablePage";
 
 const MapFloorSelectOption: React.FC<{
   selectFloor: Function;
@@ -7,7 +8,7 @@ const MapFloorSelectOption: React.FC<{
   return (
     <OptionWrapperStyled id="mapFloorOptionBox">
       {floorInfo.map((info, idx) => (
-        (info !== 4) &&
+        !(DISABLED_FLOOR.includes(info.toString())) &&
         <OptionStyled
           className="cabiButton"
           onClick={() => selectFloor(info)}

--- a/frontend/src/Cabinet/components/MapInfo/MapFloorSelectOption/MapFloorSelectOption.tsx
+++ b/frontend/src/Cabinet/components/MapInfo/MapFloorSelectOption/MapFloorSelectOption.tsx
@@ -7,6 +7,7 @@ const MapFloorSelectOption: React.FC<{
   return (
     <OptionWrapperStyled id="mapFloorOptionBox">
       {floorInfo.map((info, idx) => (
+        (info !== 4) &&
         <OptionStyled
           className="cabiButton"
           onClick={() => selectFloor(info)}

--- a/frontend/src/Cabinet/components/MapInfo/MapInfo.tsx
+++ b/frontend/src/Cabinet/components/MapInfo/MapInfo.tsx
@@ -1,7 +1,9 @@
 import styled from "styled-components";
 import MapFloorSelect from "@/Cabinet/components/MapInfo/MapFloorSelect/MapFloorSelect";
 import MapGrid from "@/Cabinet/components/MapInfo/MapGrid/MapGrid";
+import { DISABLED_FLOOR } from "@/Cabinet/pages/AvailablePage";
 
+const DEFAULT_FLOOR = 2;
 const MapInfo = ({
   touchStart,
   touchEnd,
@@ -12,11 +14,16 @@ const MapInfo = ({
 }: {
   touchStart: React.TouchEventHandler;
   touchEnd: React.TouchEventHandler;
-  floor: number;
+  floor: number | undefined;
   setFloor: React.Dispatch<React.SetStateAction<number>>;
   floorInfo: number[];
   closeMap: React.MouseEventHandler;
 }) => {
+  const currentFloor = floor ?? DEFAULT_FLOOR;
+  const validFloor = DISABLED_FLOOR.includes(currentFloor.toString())
+    ? DEFAULT_FLOOR
+    : currentFloor;
+
   return (
     <MapInfoContainerStyled
       id="mapInfo"
@@ -33,8 +40,8 @@ const MapInfo = ({
           style={{ width: "24px", cursor: "pointer" }}
         />
       </HeaderStyled>
-      <MapFloorSelect floor={floor === 4 ? 2 : floor} setFloor={setFloor} floorInfo={floorInfo} />
-      <MapGrid floor={floor === 4 ? 2 : floor} />
+      <MapFloorSelect floor={validFloor} setFloor={setFloor} floorInfo={floorInfo} />
+      <MapGrid floor={validFloor} />
     </MapInfoContainerStyled>
   );
 };

--- a/frontend/src/Cabinet/components/MapInfo/MapInfo.tsx
+++ b/frontend/src/Cabinet/components/MapInfo/MapInfo.tsx
@@ -33,8 +33,8 @@ const MapInfo = ({
           style={{ width: "24px", cursor: "pointer" }}
         />
       </HeaderStyled>
-      <MapFloorSelect floor={floor} setFloor={setFloor} floorInfo={floorInfo} />
-      <MapGrid floor={floor} />
+      <MapFloorSelect floor={floor === 4 ? 2 : floor} setFloor={setFloor} floorInfo={floorInfo} />
+      <MapGrid floor={floor === 4 ? 2 : floor} />
     </MapInfoContainerStyled>
   );
 };

--- a/frontend/src/Cabinet/pages/AvailablePage.tsx
+++ b/frontend/src/Cabinet/pages/AvailablePage.tsx
@@ -29,6 +29,7 @@ const toggleList: toggleItem[] = [
   { name: "공유", key: AvailableCabinetsType.SHARE },
 ];
 
+/* TODO: DISABLED_FLOOR 을 환경변수로 넣기 */
 export const DISABLED_FLOOR = ["4"];
 
 const AvailablePage = () => {

--- a/frontend/src/Cabinet/pages/AvailablePage.tsx
+++ b/frontend/src/Cabinet/pages/AvailablePage.tsx
@@ -29,7 +29,6 @@ const toggleList: toggleItem[] = [
   { name: "공유", key: AvailableCabinetsType.SHARE },
 ];
 
-/* TODO: DISABLED_FLOOR 을 환경변수로 넣기 */
 export const DISABLED_FLOOR = ["4"];
 
 const AvailablePage = () => {

--- a/frontend/src/Cabinet/pages/MainPage.tsx
+++ b/frontend/src/Cabinet/pages/MainPage.tsx
@@ -152,9 +152,10 @@ const MainPage = () => {
       </AlertStyled>
       <SectionPaginationContainer />
       <CabinetListWrapperStyled>
-        <CabinetListContainer isAdmin={false} />
+        <CabinetListContainer isAdmin={false} currentFloor={currentFloor} />
         {currentSectionName !== SectionType.elevator &&
-          currentSectionName !== SectionType.stairs && (
+          currentSectionName !== SectionType.stairs &&
+          currentFloor !== 4 && (
             <RefreshButtonStyled
               className="cabiButton"
               title="새로고침"

--- a/frontend/src/Cabinet/pages/MainPage.tsx
+++ b/frontend/src/Cabinet/pages/MainPage.tsx
@@ -155,7 +155,7 @@ const MainPage = () => {
         <CabinetListContainer isAdmin={false} currentFloor={currentFloor} />
         {currentSectionName !== SectionType.elevator &&
           currentSectionName !== SectionType.stairs &&
-          currentFloor !== 4 && (
+          !DISABLED_FLOOR.includes(currentFloor.toString()) && (
             <RefreshButtonStyled
               className="cabiButton"
               title="새로고침"

--- a/frontend/src/Cabinet/pages/admin/AdminMainPage.tsx
+++ b/frontend/src/Cabinet/pages/admin/AdminMainPage.tsx
@@ -118,7 +118,7 @@ const AdminMainPage = () => {
         />
       </MultiSelectButtonWrapperStyled>
       <CabinetListWrapperStyled>
-        <CabinetListContainer isAdmin={true} />
+        <CabinetListContainer isAdmin={true} currentFloor={currentFloorNumber} />
 
         <RefreshButtonStyled
           className="cabiButton"


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
<img width="1462" alt="image" src="https://github.com/user-attachments/assets/c67bd574-09c5-4822-b0e6-b53d7ba21308">

- LeftNav 에 4층 제외 (admin에서는 제외 X)
- map 도 4층 제외
- 임의로 localStorage를 통한 4층 접근 시
      1. 이용불가 안내 표시
      2. 하트, 위치안내 아이콘 제거
      3. map 은 2층을 default로 설정 (더 좋은 방법 추천받아요~)

https://github.com/innovationacademy-kr/42cabi/issues/1703
