### PR TITLE
[FE] FEAT: 기존 Sentry environment에서 development 분리 #1709

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -17,7 +17,11 @@ import { GlobalStyle } from "@/Cabinet/assets/data/ColorTheme";
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
   environment:
-    import.meta.env.VITE_IS_LOCAL === "true" ? "local" : "production",
+    import.meta.env.VITE_IS_LOCAL === "true"
+      ? "local"
+      : import.meta.env.VITE_BE_HOST.includes("dev")
+      ? "development"
+      : "production",
   release: "^8.18.0",
   integrations: [
     // See docs for support of different versions of variation of react router


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
현재 Sentry의 environment는 이분법적으로, local 여부에 따라 `local`과 `production`으로 나뉩니다.

`production` 및 `local` 환경과는 별도로 dev 브랜치 이슈만 추적하고 싶을때 `development`에서 확인할 수 있도록
**`production`에서 `development`와 `production을` 분리**했습니다.

https://github.com/innovationacademy-kr/42cabi/issues/1709
