### PR TITLE
[FE] ETC: Sentry traces sample, error replay sample 비율 상향 #1709

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -38,7 +38,7 @@ Sentry.init({
 
   // Set tracesSampleRate to 1.0 to capture 100%
   // of transactions for tracing.
-  tracesSampleRate: 0.05,
+  tracesSampleRate: 1.0,
 
   // Set `tracePropagationTargets` to control for which URLs trace propagation should be enabled
   // tracePropagationTargets: [/^\//, /^https:\/\/yourserver\.io\/api/],
@@ -52,8 +52,8 @@ Sentry.init({
 
   // Capture Replay for 100% of all sessions,
   // plus for 100% of sessions with an error
-  replaysSessionSampleRate: 0.2,
-  replaysOnErrorSampleRate: 0.2,
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
 });
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
**sentry sample rate 조정**
firebase error 발생 원인 확인하려하는데, replay 영상이 센트리에 많이 기록돼있지 않아서 추적이 어려움.
-> `tracesSampleRate`, `replaysOnErrorSampleRate` 1로 올리고, `replaysSessionSampleRate`는 에러 확인과 관련이 없는 것 같아 하향 조정.
