### PR TITLE
[FE] FIX: 수지회 신청 날짜 형식 수정 #1718

### DIFF
--- a/backend/database/cabi_local.sql
+++ b/backend/database/cabi_local.sql
@@ -809,12 +809,22 @@ LOCK TABLES `presentation` WRITE;
 /*!40000 ALTER TABLE `presentation`
     DISABLE KEYS */;
 INSERT INTO `presentation`
-VALUES (1, 'JOB', '2024-10-09 14:00:00', 'DUMMY', 'FIRST', 'EXPECTED', 'HALF', 'DUMMY', 'DUMMY', NULL),
-       (2, NULL, '2024-10-23 14:00:00', 'DUMMY', 'FIRST', 'CANCEL', 'HALF', 'DUMMY', 'DUMMY', NULL),
-       (3, NULL, '2024-11-05 14:00:00', 'DUMMY', 'FIRST', 'EXPECTED', 'HALF', 'DUMMY', 'DUMMY', NULL),
-       (4, 'JOB', '2024-11-19 14:00:00', 'DUMMY', 'FIRST', 'EXPECTED', 'HALF', 'DUMMY', 'DUMMY', NULL),
-       (5, NULL, '2024-12-11 14:00:00', 'DUMMY', 'FIRST', 'EXPECTED', 'HALF', 'DUMMY', 'DUMMY', NULL),
-       (6, 'JOB', '2024-12-25 14:00:00', 'DUMMY', 'FIRST', 'EXPECTED', 'HALF', 'DUMMY', 'DUMMY', NULL);
+VALUES (1, 'JOB', '2024-10-09 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
+       (2, NULL, '2024-10-23 14:00:00', 'dummy', 'BASEMENT', 'CANCEL', 'HALF', 'dummy', 'dummy', NULL),
+       (3, NULL, '2024-11-05 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
+       (4, 'JOB', '2024-11-19 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
+       (5, NULL, '2024-12-11 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
+       (6, 'JOB', '2024-12-25 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
+       (7, NULL, '2025-01-08 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
+       (8, NULL, '2025-01-22 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
+       (9, NULL, '2025-02-12 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
+       (10, NULL, '2025-02-26 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
+       (11, NULL, '2025-03-12 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
+       (12, NULL, '2025-03-26 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
+       (12, NULL, '2025-04-09 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
+       (12, NULL, '2025-04-23 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
+       (12, NULL, '2025-05-07 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
+       (12, NULL, '2025-05-21 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
 /*!40000 ALTER TABLE `presentation`
     ENABLE KEYS */;
 UNLOCK TABLES;

--- a/backend/database/cabi_local.sql
+++ b/backend/database/cabi_local.sql
@@ -821,10 +821,10 @@ VALUES (1, 'JOB', '2024-10-09 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF'
        (10, NULL, '2025-02-26 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
        (11, NULL, '2025-03-12 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL),
        (12, NULL, '2025-03-26 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
-       (12, NULL, '2025-04-09 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
-       (12, NULL, '2025-04-23 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
-       (12, NULL, '2025-05-07 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
-       (12, NULL, '2025-05-21 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
+       (13, NULL, '2025-04-09 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
+       (14, NULL, '2025-04-23 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
+       (15, NULL, '2025-05-07 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
+       (16, NULL, '2025-05-21 14:00:00', 'dummy', 'BASEMENT', 'EXPECTED', 'HALF', 'dummy', 'dummy', NULL);
 /*!40000 ALTER TABLE `presentation`
     ENABLE KEYS */;
 UNLOCK TABLES;

--- a/frontend/src/Presentation/components/Modals/EditStatusModal/EditStatusModal.tsx
+++ b/frontend/src/Presentation/components/Modals/EditStatusModal/EditStatusModal.tsx
@@ -66,7 +66,7 @@ const EditStatusModal = ({ list, closeModal }: EditStatusModalProps) => {
   const [presentationStatus, setPresentationStatus] =
     useState<PresentationStatusType>(PresentationStatusType.EXPECTED);
   const [location, setLocation] = useState<PresentationLocation>(
-    PresentationLocation.THIRD
+    PresentationLocation.BASEMENT
   );
   const [isStatusDropdownOpen, setIsStatusDropdownOpen] = useState(false);
   const [isDatesDropdownOpen, setIsDatesDropdownOpen] = useState(false);

--- a/frontend/src/Presentation/components/Modals/RegisterModal/RegisterModal.tsx
+++ b/frontend/src/Presentation/components/Modals/RegisterModal/RegisterModal.tsx
@@ -32,12 +32,13 @@ const RegisterModal = ({
   const [hasErrorOnResponse, setHasErrorOnResponse] = useState<boolean>(false);
   const [modalTitle, setModalTitle] = useState<string>("");
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [year, month, day] = date.split("/");
   const navigate = useNavigate();
 
   const registerDetail = `발표를 신청한 후에는 내용 수정이 <strong>불가능</strong>합니다.
 발표 날짜와 시간을 수정하고 싶으시다면
 Cabi 슬랙 채널로 문의해주세요.
-<strong>${date}</strong> 에 수요지식회 발표를 신청하시겠습니까?`;
+<strong>${month}/${day}</strong> 에 수요지식회 발표를 신청하시겠습니까?`;
 
   const closeResponseModal = (e: React.MouseEvent) => {
     closeModal(e);
@@ -45,12 +46,7 @@ Cabi 슬랙 채널로 문의해주세요.
 
   const tryRegister = async () => {
     try {
-      const [month, day] = date.split("/");
-      const data = new Date(
-        Number(new Date().getFullYear()),
-        Number(month) - 1,
-        Number(day)
-      );
+      const data = new Date(Number(year), Number(month) - 1, Number(day));
       // NOTE: Date 객체의 시간은 UTC 기준이므로 한국 시간 (GMT + 9) 으로 변환, 이후 발표 시작 시간인 14시를 더해줌
       data.setHours(9 + 14);
       await axiosPostPresentationForm(
@@ -68,7 +64,7 @@ Cabi 슬랙 채널로 문의해주세요.
       }, 1500);
       setIsFinished(true);
     } catch (error: any) {
-      setModalTitle(error.response.data.message);
+      setModalTitle(error.response);
       setHasErrorOnResponse(true);
     } finally {
       setShowResponseModal(true);

--- a/frontend/src/Presentation/components/Modals/RegisterModal/RegisterModal.tsx
+++ b/frontend/src/Presentation/components/Modals/RegisterModal/RegisterModal.tsx
@@ -64,7 +64,7 @@ Cabi 슬랙 채널로 문의해주세요.
       }, 1500);
       setIsFinished(true);
     } catch (error: any) {
-      setModalTitle(error.response);
+      setModalTitle(error.response.data.message);
       setHasErrorOnResponse(true);
     } finally {
       setShowResponseModal(true);

--- a/frontend/src/Presentation/components/Register/DropdownDateMenu.tsx
+++ b/frontend/src/Presentation/components/Register/DropdownDateMenu.tsx
@@ -31,8 +31,8 @@ const DropdownDateMenu = ({
   });
 
   const handleOptionSelect = useCallback(
-    (option: string) => {
-      setSelectedOption(option);
+    (option: string, displayOption: string) => {
+      setSelectedOption(displayOption);
       setDropdownState((prev) => ({
         ...prev,
         isVisible: false,
@@ -72,15 +72,18 @@ const DropdownDateMenu = ({
         isVisible={dropdownState.isVisible}
         clickCount={clickCount}
       >
-        {data.map((time) => (
-          <DropdownOption
-            key={time}
-            onClick={() => handleOptionSelect(time)}
-            invalid={invalidDates?.includes(time)}
-          >
-            {time}
-          </DropdownOption>
-        ))}
+        {data.map((time) => {
+          const displayTime = time.split("/").slice(1).join("/");
+          return (
+            <DropdownOption
+              key={time}
+              onClick={() => handleOptionSelect(time, displayTime)}
+              invalid={invalidDates?.includes(time)}
+            >
+              {displayTime}
+            </DropdownOption>
+          );
+        })}
       </AnimatedDropdownOptions>
     </DropdownContainer>
   );

--- a/frontend/src/Presentation/components/Register/DropdownDateMenu.tsx
+++ b/frontend/src/Presentation/components/Register/DropdownDateMenu.tsx
@@ -68,7 +68,7 @@ const DropdownDateMenu = ({
           rotated={dropdownState.isFocused}
         />
       </RegisterTimeInputStyled>
-      <AnimatedDropdownOptions
+      <AnimatedDropdownOptionsStyled
         isVisible={dropdownState.isVisible}
         clickCount={clickCount}
       >
@@ -84,7 +84,7 @@ const DropdownDateMenu = ({
             </DropdownOption>
           );
         })}
-      </AnimatedDropdownOptions>
+      </AnimatedDropdownOptionsStyled>
     </DropdownContainer>
   );
 };
@@ -119,7 +119,7 @@ const DropdownContainer = styled.div`
   position: relative;
 `;
 
-const AnimatedDropdownOptions = styled.ul<{
+const AnimatedDropdownOptionsStyled = styled.ul<{
   isVisible: boolean;
   clickCount: number;
 }>`

--- a/frontend/src/Presentation/components/Register/DropdownDateMenu.tsx
+++ b/frontend/src/Presentation/components/Register/DropdownDateMenu.tsx
@@ -72,11 +72,11 @@ const DropdownDateMenu = ({
         isVisible={dropdownState.isVisible}
         clickCount={clickCount}
       >
-        {data.map((time) => {
+        {data.map((time, index) => {
           const displayTime = time.split("/").slice(1).join("/");
           return (
             <DropdownOption
-              key={time}
+              key={index}
               onClick={() => handleOptionSelect(time, displayTime)}
               invalid={invalidDates?.includes(time)}
             >

--- a/frontend/src/Presentation/components/Register/DropdownTimeMenu.tsx
+++ b/frontend/src/Presentation/components/Register/DropdownTimeMenu.tsx
@@ -60,13 +60,13 @@ const DropdownTimeMenu = ({
         hasSelectedOption={selectedOption !== ""}
       >
         {selectedOption || "시간을 선택해주세요"}
-        <DropdownIcon
+        <DropdownIconStyled
           src={chevronIcon}
           alt="Dropdown Icon"
           rotated={dropdownState.isFocused}
         />{" "}
       </RegisterTimeInputStyled>
-      <AnimatedDropdownOptions
+      <AnimatedDropdownOptionsStyled
         isVisible={dropdownState.isVisible}
         clickCount={clickCount}
       >
@@ -75,15 +75,15 @@ const DropdownTimeMenu = ({
           .map((timeKey) => {
             const time = timeKey as PresentationTimeKey;
             return (
-              <DropdownOption
+              <DropdownOptionStyled
                 key={time}
                 onClick={() => handleOptionSelect(time)}
               >
                 {time}
-              </DropdownOption>
+              </DropdownOptionStyled>
             );
           })}
-      </AnimatedDropdownOptions>
+      </AnimatedDropdownOptionsStyled>
     </DropdownContainer>
   );
 };
@@ -118,7 +118,7 @@ const DropdownContainer = styled.div`
   position: relative;
 `;
 
-const AnimatedDropdownOptions = styled.ul<{
+const AnimatedDropdownOptionsStyled = styled.ul<{
   isVisible: boolean;
   clickCount: number;
 }>`
@@ -152,12 +152,13 @@ const AnimatedDropdownOptions = styled.ul<{
   }
 `;
 
-const DropdownOptions = styled.ul`
-  list-style-type: none;
-  padding: 0;
-`;
+// TODO: 확인 후 삭제
+// const DropdownOptions = styled.ul`
+//   list-style-type: none;
+//   padding: 0;
+// `;
 
-const DropdownOption = styled.li`
+const DropdownOptionStyled = styled.li`
   font-size: 0.875rem;
   padding: 10px;
   cursor: pointer;
@@ -194,7 +195,7 @@ const RegisterTimeInputStyled = styled.div<{
       : "var(--normal-text-color)"};
 `;
 
-const DropdownIcon = styled.img<{ rotated: boolean }>`
+const DropdownIconStyled = styled.img<{ rotated: boolean }>`
   width: 14px;
   height: 8px;
   transform: ${(props) => (props.rotated ? "rotate(180deg)" : "rotate(0deg)")};

--- a/frontend/src/Presentation/components/Register/DropdownTimeMenu.tsx
+++ b/frontend/src/Presentation/components/Register/DropdownTimeMenu.tsx
@@ -152,12 +152,6 @@ const AnimatedDropdownOptionsStyled = styled.ul<{
   }
 `;
 
-// TODO: 확인 후 삭제
-// const DropdownOptions = styled.ul`
-//   list-style-type: none;
-//   padding: 0;
-// `;
-
 const DropdownOptionStyled = styled.li`
   font-size: 0.875rem;
   padding: 10px;

--- a/frontend/src/Presentation/pages/DropdownMenu.tsx
+++ b/frontend/src/Presentation/pages/DropdownMenu.tsx
@@ -48,13 +48,16 @@ const DropdownMenu = () => {
         {selectedOption || "시간을 선택해주세요"}
       </RegisterTimeInputStyled>
       {isVisible && (
-        <DropdownOptions>
+        <DropdownOptionsStyled>
           {Object.values(PresentationTime).map((time) => (
-            <DropdownOption key={time} onClick={() => handleOptionSelect(time)}>
+            <DropdownOptionStyled
+              key={time}
+              onClick={() => handleOptionSelect(time)}
+            >
               {time}
-            </DropdownOption>
+            </DropdownOptionStyled>
           ))}
-        </DropdownOptions>
+        </DropdownOptionsStyled>
       )}
     </DropdownContainer>
   );
@@ -64,7 +67,7 @@ const DropdownContainer = styled.div`
   position: relative;
 `;
 
-const DropdownOptions = styled.ul`
+const DropdownOptionsStyled = styled.ul`
   position: absolute;
   top: 52px;
   left: 0;
@@ -82,7 +85,7 @@ const DropdownOptions = styled.ul`
   }
 `;
 
-const DropdownOption = styled.li`
+const DropdownOptionStyled = styled.li`
   font-size: 0.875rem;
   color: var(--gray-line-btn-color);
   padding: 10px;

--- a/frontend/src/Presentation/pages/RegisterPage.tsx
+++ b/frontend/src/Presentation/pages/RegisterPage.tsx
@@ -145,7 +145,6 @@ const RegisterPage = () => {
         const response = await axiosGetPresentationAbleDates();
         const availableDates = response.data.results;
         availableDates.sort();
-        console.log(availableDates);
         const formattedAvailableDates = availableDates.map(
           (dateTime: string) => {
             return format(new Date(dateTime), "y/M/d");

--- a/frontend/src/Presentation/pages/RegisterPage.tsx
+++ b/frontend/src/Presentation/pages/RegisterPage.tsx
@@ -94,7 +94,7 @@ const RegisterPage = () => {
   );
 
   const invalidDates: string[] = useInvalidDates()?.map((date) =>
-    format(date, "M/d")
+    format(date, "y/M/d")
   );
 
   const handleFocus = (sectionName: string) => {
@@ -145,9 +145,10 @@ const RegisterPage = () => {
         const response = await axiosGetPresentationAbleDates();
         const availableDates = response.data.results;
         availableDates.sort();
+        console.log(availableDates);
         const formattedAvailableDates = availableDates.map(
           (dateTime: string) => {
-            return format(new Date(dateTime), "M/d");
+            return format(new Date(dateTime), "y/M/d");
           }
         );
         setAvailableDates(formattedAvailableDates);


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [x] ETC : 이외에 다른 경우 - 컨벤션 맞춰 수정

## 설명

[수요지식회]
1. 수지회 신청 폼에서 신청 버튼을 누를 때, 신청한 날짜에서 연도는 신청 날짜 기준으로 보내지는 부분 수정
    - `getFullYear()` 사용 -> api에서 받아오는 값을 `y/M/d` 형식으로 바꾸어 출력시만 `M/d`로 변형하고, 연도도 해당 정보에서 가져오는 것으로 변경
2. `presentationLocation`의 기본 값에 대해 수지회를 만들때 정해졌던 3층이 아닌 지하 1층으로 바뀜에 따라 수정
3. 로컬에서 테스트하기 위한 케이스 5월까지 추가 (-> 현재를 기준으로 3개월만 보이는지 확인용)

[주의 해야 할 부분]
1. 한달에 발표가 재단 사정 상 2번이 불가능 한 경우 -> 추가, 삭제 관련 내용이 필요함
2. 현재 백엔드에서는 valid-date에 대해 현재 날(day) 기준, 3개월 이내의 더미에 대해 가능한 날짜에 대해 반환
    - 만약에, 현재 스케쥴러(1달에 1번 1달치)에서 변경될 경우(3개월 이후의 더미가 생성되어 있을 경우), 백엔드에서는 가능한 날짜로 넘어와서 신청이 되어도, 프론트 화면에서 볼 수 없음
    - 즉, 이 경우에는 valid-date의 기준을 '달(month)'을 기준으로 변경해야 함

https://github.com/innovationacademy-kr/42cabi/issues/1718
