### PR TITLE
어드민 슬롯 수정 기능 추가/#1762

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/admin/dto/AdminPresentationSlotUpdateRequestDto.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/dto/AdminPresentationSlotUpdateRequestDto.java
@@ -12,11 +12,11 @@ import org.jetbrains.annotations.NotNull;
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-public class AdminPresentationSlotRequestDto {
+public class AdminPresentationSlotUpdateRequestDto {
 
 	@NotNull
 	private LocalDateTime startTime;
-	
+
 	@NotNull
 	private PresentationLocation location;
 }

--- a/backend/src/main/java/org/ftclub/cabinet/admin/dto/PresentationSlotUpdateServiceDto.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/dto/PresentationSlotUpdateServiceDto.java
@@ -3,20 +3,15 @@ package org.ftclub.cabinet.admin.dto;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.ftclub.cabinet.presentation.domain.PresentationLocation;
-import org.jetbrains.annotations.NotNull;
 
 @Getter
 @ToString
-@NoArgsConstructor
 @AllArgsConstructor
-public class AdminPresentationSlotRequestDto {
+public class PresentationSlotUpdateServiceDto {
 
-	@NotNull
+	private Long slotId;
 	private LocalDateTime startTime;
-	
-	@NotNull
 	private PresentationLocation location;
 }

--- a/backend/src/main/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationSlotController.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationSlotController.java
@@ -4,7 +4,10 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.ftclub.cabinet.admin.dto.AdminPresentationSlotRequestDto;
 import org.ftclub.cabinet.admin.dto.PresentationSlotRegisterServiceDto;
+import org.ftclub.cabinet.admin.dto.PresentationSlotUpdateServiceDto;
 import org.ftclub.cabinet.admin.presentation.service.AdminPresentationSlotService;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,6 +31,24 @@ public class AdminPresentationSlotController {
 			@RequestBody @Valid AdminPresentationSlotRequestDto slotRequestDto) {
 		adminPresentationSlotService.registerPresentationSlot(
 				new PresentationSlotRegisterServiceDto(
+						slotRequestDto.getStartTime(),
+						slotRequestDto.getLocation()
+				));
+	}
+
+	/**
+	 * 프레젠테이션 슬롯을 업데이트합니다.
+	 *
+	 * @param slotRequestDto 프레젠테이션 슬롯 업데이트 요청 DTO
+	 * @param slotId         프레젠테이션 슬롯 ID
+	 */
+	@PatchMapping("/slots/{slotId}")
+	public void updatePresentationSlot(
+			@RequestBody @Valid AdminPresentationSlotRequestDto slotRequestDto,
+			@PathVariable("slotId") Long slotId) {
+		adminPresentationSlotService.updatePresentationSlot(
+				new PresentationSlotUpdateServiceDto(
+						slotId,
 						slotRequestDto.getStartTime(),
 						slotRequestDto.getLocation()
 				));

--- a/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotService.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.ftclub.cabinet.admin.dto.PresentationSlotRegisterServiceDto;
+import org.ftclub.cabinet.admin.dto.PresentationSlotUpdateServiceDto;
 import org.ftclub.cabinet.exception.ExceptionStatus;
 import org.ftclub.cabinet.presentation.domain.PresentationSlot;
 import org.ftclub.cabinet.presentation.repository.PresentationSlotRepository;
@@ -62,5 +63,15 @@ public class AdminPresentationSlotService {
 		if (!overlappingSlots.isEmpty()) {
 			throw ExceptionStatus.SLOT_ALREADY_EXISTS.asServiceException();
 		}
+	}
+
+	/**
+	 * 프레젠테이션 슬롯을 업데이트합니다.
+	 *
+	 * @param serviceDto 프레젠테이션 슬롯 정보
+	 */
+	public void updatePresentationSlot(
+			PresentationSlotUpdateServiceDto serviceDto) {
+
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotService.java
@@ -66,12 +66,37 @@ public class AdminPresentationSlotService {
 	}
 
 	/**
+	 * 프레젠테이션 슬롯이 겹치는지 확인합니다.
+	 *
+	 * @param slotId       슬롯 ID
+	 * @param newStartTime 시작 시간
+	 */
+	private void validateSlotUpdateOverlap(Long slotId, LocalDateTime newStartTime) {
+		LocalDateTime overlapStartTime = newStartTime.minusHours(PRESENTATION_SLOT_DURATION);
+		LocalDateTime overlapEndTime = newStartTime.plusHours(PRESENTATION_SLOT_DURATION);
+
+		List<PresentationSlot> overlappingSlots = slotRepository.findByStartTimeBetween(
+				overlapStartTime, overlapEndTime);
+
+		if (overlappingSlots.size() > 1 ||
+				(overlappingSlots.size() == 1 && !overlappingSlots.get(0).getId().equals(slotId))) {
+			throw ExceptionStatus.SLOT_ALREADY_EXISTS.asServiceException();
+		}
+	}
+
+	/**
 	 * 프레젠테이션 슬롯을 업데이트합니다.
 	 *
 	 * @param serviceDto 프레젠테이션 슬롯 정보
 	 */
 	public void updatePresentationSlot(
 			PresentationSlotUpdateServiceDto serviceDto) {
-
+		PresentationSlot slot = slotRepository.findById(serviceDto.getSlotId())
+				.orElseThrow(ExceptionStatus.SLOT_NOT_FOUND::asServiceException);
+		validateSlotPassed(serviceDto.getStartTime());
+		validateSlotUpdateOverlap(serviceDto.getSlotId(), serviceDto.getStartTime());
+		slot.changeSlotStartTime(serviceDto.getStartTime());
+		slot.changeSlotLocation(serviceDto.getLocation());
+		// TODO : 프레젠테이션에 연결된 발표 정보도 수정해야 한다면 발표 수정 기능 개발 후에 추가
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionStatus.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionStatus.java
@@ -119,7 +119,8 @@ public enum ExceptionStatus {
 
 	// Presentation 관련
 	CANNOT_CREATE_SLOT_IN_PAST(HttpStatus.BAD_REQUEST, "과거 시간으로는 발표 슬롯을 생성할 수 없습니다."),
-	SLOT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "해당 시간에는 이미 발표 슬롯이 존재합니다.");
+	SLOT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "해당 시간에는 이미 발표 슬롯이 존재합니다."),
+	SLOT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 발표 슬롯이 존재하지 않습니다.");
 
 	final private int statusCode;
 	final private String message;

--- a/backend/src/main/java/org/ftclub/cabinet/presentation/domain/PresentationSlot.java
+++ b/backend/src/main/java/org/ftclub/cabinet/presentation/domain/PresentationSlot.java
@@ -15,6 +15,7 @@ import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.ftclub.cabinet.exception.ExceptionStatus;
 
 @Entity
 @Getter
@@ -44,4 +45,16 @@ public class PresentationSlot {
 		this.presentationLocation = presentationLocation;
 		this.presentation = null;
 	}
+
+	public void changeSlotStartTime(LocalDateTime startTime) {
+		if (this.startTime.isBefore(java.time.LocalDateTime.now())) {
+			throw ExceptionStatus.CANNOT_CREATE_SLOT_IN_PAST.asDomainException();
+		}
+		this.startTime = startTime;
+	}
+
+	public void changeSlotLocation(PresentationLocation location) {
+		this.presentationLocation = location;
+	}
+
 }

--- a/backend/src/test/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationSlotControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationSlotControllerTest.java
@@ -65,4 +65,22 @@ class AdminPresentationSlotControllerTest {
 				.andExpect(MockMvcResultMatchers.status().isForbidden());
 	}
 
+	@DisplayName("어드민이 프레젠테이션 슬롯을 수정한다.")
+	@WithMockUser(roles = "ADMIN")
+	@Test
+	void updatePresentationSlot() throws Exception {
+		// given
+		Long slotId = 1L;
+		AdminPresentationSlotRequestDto requestDto = new AdminPresentationSlotRequestDto(
+				LocalDateTime.now().plusDays(1),
+				PresentationLocation.BASEMENT
+		);
+		// then
+		mockMvc.perform(
+						MockMvcRequestBuilders.patch("/v6/admin/presentations/slots/{slotId}", slotId)
+								.contentType(MediaType.APPLICATION_JSON)
+								.content(objectMapper.writeValueAsString(requestDto))
+				)
+				.andExpect(MockMvcResultMatchers.status().isOk());
+	}
 }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1762

어드민 슬롯 수정 기능 추가하였습니다!
각 레이어에 대해 테스트 코드 작성했고, 포스트맨 테스트도 로컬에서나마 진행해보았습니다.
기획때 슬롯 수정하면 슬롯에 연결된 발표도 같이 수정되게 하기로 했는지 정확히 기억이 안나고
아직 발표 수정 기능도 개발이 안돼있어서
일단 발표쪽은 빼고 슬롯부분만 기능 만들었습니다.
크게 추가된 로직은 없어서 그냥 훑어만 보시고 혹시 문제가 있다면 알려주시오.
