### PR TITLE
Be/presentation renewal/feat delete slot/#1764

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationSlotController.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationSlotController.java
@@ -8,6 +8,8 @@ import org.ftclub.cabinet.admin.dto.PresentationSlotUpdateServiceDto;
 import org.ftclub.cabinet.admin.presentation.service.AdminPresentationSlotService;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -52,5 +54,15 @@ public class AdminPresentationSlotController {
 						slotRequestDto.getStartTime(),
 						slotRequestDto.getLocation()
 				));
+	}
+
+	/**
+	 * 프레젠테이션 슬롯을 삭제합니다.
+	 *
+	 * @param slotId 프레젠테이션 슬롯 ID
+	 */
+	@DeleteMapping("/slots/{slotId}")
+	public void deletePresentationSlot(@PathVariable Long slotId) {
+		adminPresentationSlotService.deletePresentationSlot(slotId);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotService.java
@@ -55,8 +55,8 @@ public class AdminPresentationSlotService {
 	 */
 	@Transactional(readOnly = true)
 	public void validateSlotOverlapped(LocalDateTime startTime) {
-		LocalDateTime overlapStartTime = startTime.minusHours(PRESENTATION_SLOT_DURATION);
-		LocalDateTime overlapEndTime = startTime.plusHours(PRESENTATION_SLOT_DURATION);
+		LocalDateTime overlapStartTime = startTime.minusMinutes(PRESENTATION_SLOT_DURATION);
+		LocalDateTime overlapEndTime = startTime.plusMinutes(PRESENTATION_SLOT_DURATION);
 
 		List<PresentationSlot> overlappingSlots = slotRepository.findByStartTimeBetween(
 				overlapStartTime, overlapEndTime);
@@ -74,8 +74,8 @@ public class AdminPresentationSlotService {
 	 */
 	@Transactional(readOnly = true)
 	public void validateSlotUpdateOverlap(Long slotId, LocalDateTime newStartTime) {
-		LocalDateTime overlapStartTime = newStartTime.minusHours(PRESENTATION_SLOT_DURATION);
-		LocalDateTime overlapEndTime = newStartTime.plusHours(PRESENTATION_SLOT_DURATION);
+		LocalDateTime overlapStartTime = newStartTime.minusMinutes(PRESENTATION_SLOT_DURATION);
+		LocalDateTime overlapEndTime = newStartTime.plusMinutes(PRESENTATION_SLOT_DURATION);
 
 		List<PresentationSlot> overlappingSlots = slotRepository.findByStartTimeBetween(
 				overlapStartTime, overlapEndTime);

--- a/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotService.java
@@ -53,7 +53,8 @@ public class AdminPresentationSlotService {
 	 *
 	 * @param startTime
 	 */
-	private void validateSlotOverlapped(LocalDateTime startTime) {
+	@Transactional(readOnly = true)
+	public void validateSlotOverlapped(LocalDateTime startTime) {
 		LocalDateTime overlapStartTime = startTime.minusHours(PRESENTATION_SLOT_DURATION);
 		LocalDateTime overlapEndTime = startTime.plusHours(PRESENTATION_SLOT_DURATION);
 
@@ -71,7 +72,8 @@ public class AdminPresentationSlotService {
 	 * @param slotId       슬롯 ID
 	 * @param newStartTime 시작 시간
 	 */
-	private void validateSlotUpdateOverlap(Long slotId, LocalDateTime newStartTime) {
+	@Transactional(readOnly = true)
+	public void validateSlotUpdateOverlap(Long slotId, LocalDateTime newStartTime) {
 		LocalDateTime overlapStartTime = newStartTime.minusHours(PRESENTATION_SLOT_DURATION);
 		LocalDateTime overlapEndTime = newStartTime.plusHours(PRESENTATION_SLOT_DURATION);
 
@@ -98,5 +100,19 @@ public class AdminPresentationSlotService {
 		slot.changeSlotStartTime(serviceDto.getStartTime());
 		slot.changeSlotLocation(serviceDto.getLocation());
 		// TODO : 프레젠테이션에 연결된 발표 정보도 수정해야 한다면 발표 수정 기능 개발 후에 추가
+	}
+
+	/**
+	 * 프레젠테이션 슬롯을 삭제합니다.
+	 *
+	 * @param slotId 프레젠테이션 슬롯 ID
+	 */
+	public void deletePresentationSlot(Long slotId) {
+		PresentationSlot slot = slotRepository.findById(slotId)
+				.orElseThrow(ExceptionStatus.SLOT_NOT_FOUND::asServiceException);
+		if (slot.hasPresentation()) {
+			throw ExceptionStatus.CANNOT_DELETE_SLOT_WITH_PRESENTATION.asServiceException();
+		}
+		slotRepository.delete(slot);
 	}
 }

--- a/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionStatus.java
+++ b/backend/src/main/java/org/ftclub/cabinet/exception/ExceptionStatus.java
@@ -121,12 +121,13 @@ public enum ExceptionStatus {
 	CANNOT_CREATE_SLOT_IN_PAST(HttpStatus.BAD_REQUEST, "과거 시간으로는 발표 슬롯을 생성할 수 없습니다."),
 	SLOT_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "해당 시간에는 이미 발표 슬롯이 존재합니다."),
 	SLOT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 발표 슬롯이 존재하지 않습니다."),
+	CANNOT_DELETE_SLOT_WITH_PRESENTATION(HttpStatus.BAD_REQUEST, "발표가 있는 슬롯은 삭제할 수 없습니다."),
 	FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "파일 크기가 너무 큽니다."),
 	INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "잘못된 파일 확장자입니다."),
 	S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드 중 에러가 발생했습니다."),
 	S3_GET_URL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 URL 생성 중 에러가 발생했습니다."),
 	S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3 삭제 중 에러가 발생했습니다."),
-
+	PRESENTATION_SLOT_ALREADY_ASSIGNED(HttpStatus.BAD_REQUEST, "이미 발표 슬롯에 발표가 할당되어 있습니다."),
 
 	// Presentation user 권한 관련
 	NOT_LOGGED_IN(HttpStatus.UNAUTHORIZED, "로그인이 필요한 서비스입니다."),

--- a/backend/src/main/java/org/ftclub/cabinet/presentation/domain/PresentationSlot.java
+++ b/backend/src/main/java/org/ftclub/cabinet/presentation/domain/PresentationSlot.java
@@ -57,4 +57,15 @@ public class PresentationSlot {
 		this.presentationLocation = location;
 	}
 
+	public boolean hasPresentation() {
+		return this.presentation != null;
+	}
+
+	public void assignPresentation(Presentation presentation) {
+		if (this.presentation != null) {
+			throw ExceptionStatus.PRESENTATION_SLOT_ALREADY_ASSIGNED.asDomainException();
+		}
+		this.presentation = presentation;
+	}
+
 }

--- a/backend/src/main/java/org/ftclub/cabinet/presentation/domain/PresentationSlot.java
+++ b/backend/src/main/java/org/ftclub/cabinet/presentation/domain/PresentationSlot.java
@@ -23,7 +23,7 @@ import org.ftclub.cabinet.exception.ExceptionStatus;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PresentationSlot {
 
-	public static final int PRESENTATION_SLOT_DURATION = 2;
+	public static final int PRESENTATION_SLOT_DURATION = 30; // 30분
 
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "ID")

--- a/backend/src/test/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationSlotControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationSlotControllerTest.java
@@ -83,4 +83,18 @@ class AdminPresentationSlotControllerTest {
 				)
 				.andExpect(MockMvcResultMatchers.status().isOk());
 	}
+
+	@DisplayName("어드민이 프레젠테이션 슬롯을 삭제한다.")
+	@WithMockUser(roles = "ADMIN")
+	@Test
+	void deletePresentationSlot() throws Exception {
+		// given
+		Long slotId = 1L;
+		// then
+		mockMvc.perform(
+						MockMvcRequestBuilders.delete("/v6/admin/presentations/slots/{slotId}", slotId))
+				.andExpect(MockMvcResultMatchers.status().isOk());
+	}
+
+
 }

--- a/backend/src/test/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotServiceTest.java
@@ -10,6 +10,8 @@ import org.ftclub.cabinet.exception.ServiceException;
 import org.ftclub.cabinet.presentation.domain.PresentationLocation;
 import org.ftclub.cabinet.presentation.domain.PresentationSlot;
 import org.ftclub.cabinet.presentation.repository.PresentationSlotRepository;
+import org.ftclub.cabinet.presentation.service.PresentationFacadeService;
+import org.ftclub.cabinet.user.service.UserFacadeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +27,12 @@ class AdminPresentationSlotServiceTest {
 
 	@Autowired
 	private AdminPresentationSlotService slotService;
+
+	@Autowired
+	private PresentationFacadeService presentationFacadeService;
+
+	@Autowired
+	private UserFacadeService userFacadeService;
 
 	@DisplayName("어드민이 프레젠테이션 슬롯을 생성하여 등록한다.")
 	@Test
@@ -189,5 +197,25 @@ class AdminPresentationSlotServiceTest {
 				)))
 				.isInstanceOf(ServiceException.class)
 				.hasMessage("해당 시간에는 이미 발표 슬롯이 존재합니다.");
+	}
+
+	@DisplayName("어드민이 프레젠테이션이 지정되지 않은 슬롯을 삭제한다.")
+	@Test
+	void deletePresentationSlot() {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		PresentationSlotRegisterServiceDto slotServiceDto = new PresentationSlotRegisterServiceDto(
+				now.plusHours(1),
+				PresentationLocation.BASEMENT
+		);
+		slotService.registerPresentationSlot(slotServiceDto);
+
+		Long slotId = slotRepository.findAll().get(0).getId();
+
+		// when
+		slotService.deletePresentationSlot(slotId);
+
+		// then
+		assertThat(slotRepository.findById(slotId)).isEmpty();
 	}
 }

--- a/backend/src/test/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotServiceTest.java
@@ -53,7 +53,7 @@ class AdminPresentationSlotServiceTest {
 		assertThat(savedSlot.getStartTime()).isEqualTo(slotServiceDto.getStartTime());
 	}
 
-	@DisplayName("어드민이 프레젠테이션 슬롯을 2시간 간격으로 연속하여 등록한다")
+	@DisplayName("어드민이 프레젠테이션 슬롯을 30분 간격으로 연속하여 등록한다")
 	@Test
 	void registerTwoPresentationSlots() {
 		// given
@@ -65,7 +65,7 @@ class AdminPresentationSlotServiceTest {
 		slotService.registerPresentationSlot(slotServiceDto1);
 
 		PresentationSlotRegisterServiceDto slotServiceDto2 = new PresentationSlotRegisterServiceDto(
-				now.plusHours(3),
+				now.plusHours(1).plusMinutes(30),
 				PresentationLocation.BASEMENT
 		);
 
@@ -104,7 +104,7 @@ class AdminPresentationSlotServiceTest {
 		slotService.registerPresentationSlot(slotServiceDto1);
 
 		PresentationSlotRegisterServiceDto slotServiceDto2 = new PresentationSlotRegisterServiceDto(
-				now.plusHours(2),
+				now.plusHours(1).plusMinutes(20),
 				PresentationLocation.BASEMENT
 		);
 
@@ -192,7 +192,7 @@ class AdminPresentationSlotServiceTest {
 		assertThatThrownBy(
 				() -> slotService.updatePresentationSlot(new PresentationSlotUpdateServiceDto(
 						slotId,
-						now.plusHours(2),
+						now.plusHours(2).plusMinutes(40),
 						PresentationLocation.BASEMENT
 				)))
 				.isInstanceOf(ServiceException.class)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/#1764

어드민에서 슬롯 삭제하는 기능 구현했습니다.
슬롯에 이미 등록된 발표가 있으면 삭제는 안되는걸로 에러처리 해놨습니다. 
발표쪽에서 등록할때 슬롯에도 등록할수 있도록 PresentationSlot 클래스에 assignPresentation 메서드도 살짝 넣어놨습니다.
테스트 코드 작성, 포스트맨으로 엔드투엔드 테스트까지 완료 했습니다.
슥 보시고 리뷰 해주세요~
