### PR TITLE
Be/presentation renewal/feat get slots/#1795

### DIFF
--- a/backend/src/main/java/org/ftclub/cabinet/config/TimeConfig.java
+++ b/backend/src/main/java/org/ftclub/cabinet/config/TimeConfig.java
@@ -1,0 +1,15 @@
+package org.ftclub.cabinet.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+	@Bean
+	public Clock clock() {
+		// 시스템의 기본 시간대를 사용하여 Clock을 생성합니다.
+		return Clock.systemDefaultZone();
+	}
+}

--- a/backend/src/main/java/org/ftclub/cabinet/dto/AvailablePresentationSlotDto.java
+++ b/backend/src/main/java/org/ftclub/cabinet/dto/AvailablePresentationSlotDto.java
@@ -1,0 +1,17 @@
+package org.ftclub.cabinet.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class AvailablePresentationSlotDto {
+
+	private Long slotId;
+	private LocalDateTime startTime;
+}

--- a/backend/src/main/java/org/ftclub/cabinet/presentation/controller/PresentationSlotController.java
+++ b/backend/src/main/java/org/ftclub/cabinet/presentation/controller/PresentationSlotController.java
@@ -1,0 +1,22 @@
+package org.ftclub.cabinet.presentation.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.ftclub.cabinet.dto.AvailablePresentationSlotDto;
+import org.ftclub.cabinet.presentation.dto.DataListResponseDto;
+import org.ftclub.cabinet.presentation.service.PresentationSlotService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v6/presentations")
+@RequiredArgsConstructor
+public class PresentationSlotController {
+
+	private final PresentationSlotService presentationSlotService;
+
+	@GetMapping("/slots")
+	public DataListResponseDto<AvailablePresentationSlotDto> getPresentationSlots() {
+		return presentationSlotService.getPresentationSlots();
+	}
+}

--- a/backend/src/main/java/org/ftclub/cabinet/presentation/service/PresentationSlotService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/presentation/service/PresentationSlotService.java
@@ -1,0 +1,37 @@
+package org.ftclub.cabinet.presentation.service;
+
+import static org.ftclub.cabinet.presentation.domain.PresentationSlot.ALLOWED_PERIOD;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.ftclub.cabinet.dto.AvailablePresentationSlotDto;
+import org.ftclub.cabinet.presentation.dto.DataListResponseDto;
+import org.ftclub.cabinet.presentation.repository.PresentationSlotRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PresentationSlotService {
+
+	private static final int FIRST_DAY_OF_MONTH = 1;
+	private final PresentationSlotRepository presentationSlotRepository;
+
+	public static LocalDateTime calculateEndTime(LocalDateTime now) {
+		YearMonth targetMonth = YearMonth.from(now).plusMonths(ALLOWED_PERIOD);
+		return targetMonth.atDay(FIRST_DAY_OF_MONTH).atStartOfDay();
+	}
+
+	public DataListResponseDto<AvailablePresentationSlotDto> getPresentationSlots() {
+		LocalDateTime now = LocalDateTime.now();
+		List<AvailablePresentationSlotDto> slotList = presentationSlotRepository.findByStartTimeBetween(
+						now,
+						calculateEndTime(now)).stream().filter(slot -> !slot.hasPresentation()).
+				map(slot -> new AvailablePresentationSlotDto(slot.getId(),
+						slot.getStartTime())
+				).collect(Collectors.toList());
+		return new DataListResponseDto<>(slotList);
+	}
+}

--- a/backend/src/main/java/org/ftclub/cabinet/presentation/service/PresentationSlotService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/presentation/service/PresentationSlotService.java
@@ -2,6 +2,7 @@ package org.ftclub.cabinet.presentation.service;
 
 import static org.ftclub.cabinet.presentation.domain.PresentationSlot.ALLOWED_PERIOD;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
@@ -18,6 +19,7 @@ public class PresentationSlotService {
 
 	private static final int FIRST_DAY_OF_MONTH = 1;
 	private final PresentationSlotRepository presentationSlotRepository;
+	private final Clock clock;
 
 	public static LocalDateTime calculateEndTime(LocalDateTime now) {
 		YearMonth targetMonth = YearMonth.from(now).plusMonths(ALLOWED_PERIOD);
@@ -25,7 +27,7 @@ public class PresentationSlotService {
 	}
 
 	public DataListResponseDto<AvailablePresentationSlotDto> getPresentationSlots() {
-		LocalDateTime now = LocalDateTime.now();
+		LocalDateTime now = LocalDateTime.now(clock);
 		List<AvailablePresentationSlotDto> slotList = presentationSlotRepository.findByStartTimeBetween(
 						now,
 						calculateEndTime(now)).stream().filter(slot -> !slot.hasPresentation()).

--- a/backend/src/main/java/org/ftclub/cabinet/security/SecurityConfig.java
+++ b/backend/src/main/java/org/ftclub/cabinet/security/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
 						.mvcMatchers(SecurityPathPatterns.AGU_ENDPOINTS)
 						.hasAnyRole("AGU", "USER")
 						.mvcMatchers(HttpMethod.GET, SecurityPathPatterns.ANONYMOUS_ENDPOINTS)
-						.hasAnyRole("ANONYMOUS", "USER")
+						.permitAll()
 						.anyRequest().hasRole("USER")
 				)
 				.oauth2Login(oauth -> oauth

--- a/backend/src/main/java/org/ftclub/cabinet/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/org/ftclub/cabinet/security/filter/JwtAuthenticationFilter.java
@@ -50,14 +50,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			FilterChain filterChain) throws ServletException, IOException {
 		String token = jwtService.extractToken(request);
 		if (token != null) {
-			UserInfoDto userInfoDto = jwtService.validateTokenAndGetUserInfo(token);
-			Authentication auth = getAuthentication(userInfoDto);
+			try {
+				UserInfoDto userInfoDto = jwtService.validateTokenAndGetUserInfo(token);
+				Authentication auth = getAuthentication(userInfoDto);
 
-			log.debug("JWT Filter: userId = {}, role = {}",
-					userInfoDto.getUserId(),
-					userInfoDto.getRoles()
-			);
-			SecurityContextHolder.getContext().setAuthentication(auth);
+				log.debug("JWT Filter: userId = {}, role = {}",
+						userInfoDto.getUserId(),
+						userInfoDto.getRoles()
+				);
+				SecurityContextHolder.getContext().setAuthentication(auth);
+			} catch (Exception e) {
+				log.warn("JWT token validation failed: {}. Proceeding as anonymous.",
+						e.getMessage());
+			}
 		}
 		filterChain.doFilter(request, response);
 	}

--- a/backend/src/test/java/org/ftclub/cabinet/presentation/service/PresentationSlotServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/presentation/service/PresentationSlotServiceTest.java
@@ -1,0 +1,75 @@
+package org.ftclub.cabinet.presentation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.ftclub.cabinet.presentation.domain.PresentationLocation.BASEMENT;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.ftclub.cabinet.dto.AvailablePresentationSlotDto;
+import org.ftclub.cabinet.presentation.domain.PresentationSlot;
+import org.ftclub.cabinet.presentation.dto.DataListResponseDto;
+import org.ftclub.cabinet.presentation.repository.PresentationRepository;
+import org.ftclub.cabinet.presentation.repository.PresentationSlotRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class PresentationSlotServiceTest {
+
+	@Autowired
+	private PresentationSlotService presentationSlotService;
+
+	@Autowired
+	private PresentationSlotRepository presentationSlotRepository;
+
+	@Autowired
+	private PresentationRepository presentationRepository;
+
+	@MockBean
+	private Clock clock;
+
+	@BeforeEach
+	void setUp() {
+		presentationRepository.deleteAllInBatch();
+		presentationSlotRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("현재시간 기준으로 3개월 안의 예약되지 않은 슬롯을 조회한다")
+	@Test
+	void test() {
+		// given
+		LocalDateTime fixedNow = LocalDateTime.of(2025, 7, 10, 15, 0, 0);
+		Instant instant = fixedNow.atZone(ZoneId.systemDefault()).toInstant();
+		when(clock.instant()).thenReturn(instant);
+		when(clock.getZone()).thenReturn(ZoneId.systemDefault());
+
+		PresentationSlot slot1 = new PresentationSlot(fixedNow.minusDays(1), BASEMENT);
+		PresentationSlot slot2 = new PresentationSlot(fixedNow.plusMonths(1), BASEMENT);
+		PresentationSlot slot3 = new PresentationSlot(fixedNow.plusMonths(2), BASEMENT);
+		PresentationSlot slot4 = new PresentationSlot(fixedNow.plusMonths(3), BASEMENT);
+
+		presentationSlotRepository.saveAll(List.of(slot1, slot2, slot3, slot4));
+		// when
+
+		DataListResponseDto<AvailablePresentationSlotDto> slots = presentationSlotService.getPresentationSlots();
+
+		// then
+		assertThat(slots).isNotNull();
+		assertThat(slots.getData()).extracting(AvailablePresentationSlotDto::getStartTime)
+				.containsExactlyInAnyOrder(
+						slot2.getStartTime(),
+						slot3.getStartTime()
+				);
+	}
+
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [x] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [x] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738

https://github.com/innovationacademy-kr/42cabi/issues/1795


신청페이지에서 유저가 사용가능한 슬롯을 조회하는 기능을 구현했습니다.

현재날짜기준 3개월까지의 슬롯이 조회됩니다. (조회시점이 6월 24일이라면 6월 25일부터 8월 31일 전까지의 슬롯이 조회됨)

인증과 권한 필요없이 누구나 호출 가능하게 만들기 위해 스프링 시큐리티 설정을 다소 변경하였습니다.

테스트는 파라미터가 없기 때문에 컨트롤러는 만들지 않았고, 서비스만 성공 테스트 만들었습니다.
실패 테스트도 만들려고 했는데  빈 리스트가 나올순 있어도 실패하는 경우는 없더라구요.

자세한 내용은 커밋에서...
