### PR TITLE
[BE] FIX: 삭제된 댓글 조회 버그 수정 및 테스트 DB 환경 개선 #1806

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-junit-jupiter:3.9.0'
     implementation 'javax.servlet:javax.servlet-api:4.0.1'
     testImplementation 'org.modelmapper:modelmapper:3.1.1'
-    testRuntimeOnly 'com.h2database:h2'
+    testRuntimeOnly 'com.h2database:h2:2.1.214'
 
     // springdoc
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationCommentService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationCommentService.java
@@ -26,7 +26,8 @@ public class AdminPresentationCommentService {
 		presentationQueryService.findPresentationByIdWithUser(presentationId);
 
 		List<PresentationComment> comments =
-				commentRepository.findByPresentationIdOrderByCreatedAtAsc(presentationId);
+				commentRepository.findByPresentationIdAndDeletedFalseOrderByCreatedAtAsc(
+						presentationId);
 
 		return comments.stream()
 				.map(comment -> new PresentationCommentResponseDto(

--- a/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotService.java
@@ -123,8 +123,10 @@ public class AdminPresentationSlotService {
 		validateSlotUpdateOverlap(serviceDto.getSlotId(), serviceDto.getStartTime());
 		slot.changeSlotStartTime(serviceDto.getStartTime());
 		slot.changeSlotLocation(serviceDto.getPresentationLocation());
-		presentationCommandService.updateSlotDetails(slot.getPresentation().getId(),
-				slot.getStartTime(), slot.getPresentationLocation());
+		if (slot.hasPresentation()) {
+			presentationCommandService.updateSlotDetails(slot.getPresentation().getId(),
+					slot.getStartTime(), slot.getPresentationLocation());
+		}
 	}
 
 	/**

--- a/backend/src/main/java/org/ftclub/cabinet/presentation/repository/PresentationCommentRepository.java
+++ b/backend/src/main/java/org/ftclub/cabinet/presentation/repository/PresentationCommentRepository.java
@@ -6,5 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PresentationCommentRepository extends JpaRepository<PresentationComment, Long> {
 
-	List<PresentationComment> findByPresentationIdOrderByCreatedAtAsc(Long presentationId);
+	List<PresentationComment> findByPresentationIdAndDeletedFalseOrderByCreatedAtAsc(
+			Long presentationId);
+
 }

--- a/backend/src/main/java/org/ftclub/cabinet/presentation/service/PresentationCommentService.java
+++ b/backend/src/main/java/org/ftclub/cabinet/presentation/service/PresentationCommentService.java
@@ -66,7 +66,7 @@ public class PresentationCommentService {
 		// Presentation 존재하는지 확인
 		presentationQueryService.findPresentationByIdWithUser(presentationId);
 
-		List<PresentationComment> comments = commentRepository.findByPresentationIdOrderByCreatedAtAsc(
+		List<PresentationComment> comments = commentRepository.findByPresentationIdAndDeletedFalseOrderByCreatedAtAsc(
 				presentationId);
 
 		return comments.stream()

--- a/backend/src/test/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationControllerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import org.ftclub.cabinet.admin.dto.AdminPresentationCalendarItemDto;
+import org.ftclub.cabinet.event.RedisExpirationEventListener;
 import org.ftclub.cabinet.mapper.PresentationMapper;
 import org.ftclub.cabinet.presentation.domain.Category;
 import org.ftclub.cabinet.presentation.domain.Duration;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
@@ -60,6 +62,9 @@ class AdminPresentationControllerTest {
 
 	@Autowired
 	private EntityManager entityManager;
+
+	@MockBean
+	private RedisExpirationEventListener redisExpirationEventListener;
 
 	// sample data for realistic tests -> setUp
 	private User testUser1, testUser2;

--- a/backend/src/test/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationControllerTest.java
@@ -30,7 +30,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +37,6 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest
 @AutoConfigureMockMvc
 @Transactional
-@ActiveProfiles("local")
 class AdminPresentationControllerTest {
 
 	private static final String BASE_URL = "/v6/admin/presentations";

--- a/backend/src/test/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationSlotControllerTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/admin/presentation/controller/AdminPresentationSlotControllerTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
 import org.ftclub.cabinet.admin.dto.AdminPresentationSlotRequestDto;
 import org.ftclub.cabinet.admin.presentation.service.AdminPresentationSlotService;
+import org.ftclub.cabinet.event.RedisExpirationEventListener;
 import org.ftclub.cabinet.presentation.domain.PresentationLocation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +31,9 @@ class AdminPresentationSlotControllerTest {
 
 	@MockBean
 	private AdminPresentationSlotService adminPresentationSlotService;
+
+	@MockBean
+	private RedisExpirationEventListener redisExpirationEventListener;
 
 	@DisplayName("어드민이 프레젠테이션 슬롯을 생성하여 등록한다.")
 	@WithMockUser(roles = "ADMIN")

--- a/backend/src/test/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationCommentServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationCommentServiceTest.java
@@ -35,7 +35,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 @Transactional
-@ActiveProfiles("local")
 class AdminPresentationCommentServiceTest {
 
 	@Autowired

--- a/backend/src/test/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationCommentServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationCommentServiceTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.boot.test.mock.mockito.MockBean;
 

--- a/backend/src/test/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/admin/presentation/service/AdminPresentationSlotServiceTest.java
@@ -3,8 +3,6 @@ package org.ftclub.cabinet.admin.presentation.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,6 +10,7 @@ import org.ftclub.cabinet.admin.dto.PresentationSlotRegisterServiceDto;
 import org.ftclub.cabinet.admin.dto.PresentationSlotResponseDto;
 import org.ftclub.cabinet.admin.dto.PresentationSlotSearchServiceDto;
 import org.ftclub.cabinet.admin.dto.PresentationSlotUpdateServiceDto;
+import org.ftclub.cabinet.event.RedisExpirationEventListener;
 import org.ftclub.cabinet.exception.ServiceException;
 import org.ftclub.cabinet.presentation.domain.Category;
 import org.ftclub.cabinet.presentation.domain.Duration;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
@@ -44,8 +42,11 @@ class AdminPresentationSlotServiceTest {
 	@Autowired
 	private PresentationRepository presentationRepository;
 
-	@MockBean
+	@Autowired
 	private UserRepository userRepository;
+
+	@MockBean
+	private RedisExpirationEventListener redisExpirationEventListener;
 
 	private User testUser1;
 
@@ -54,13 +55,13 @@ class AdminPresentationSlotServiceTest {
 		User userToSave1 = User.of("jongmlee", "jongmlee@gmail.com",
 				LocalDateTime.now().plusMonths(10),
 				"MEMBER");
-		when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
-			User userArg = invocation.getArgument(0);
-			if (userArg.getId() == null) { // ID가 아직 없는 새 엔티티라면
-				ReflectionTestUtils.setField(userArg, "id", 1L); // 임의의 ID (testUser1 용)
-			}
-			return userArg;
-		});
+//		when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+//			User userArg = invocation.getArgument(0);
+//			if (userArg.getId() == null) { // ID가 아직 없는 새 엔티티라면
+//				ReflectionTestUtils.setField(userArg, "id", 1L); // 임의의 ID (testUser1 용)
+//			}
+//			return userArg;
+//		});
 		testUser1 = userRepository.save(userToSave1);
 	}
 
@@ -274,7 +275,7 @@ class AdminPresentationSlotServiceTest {
 
 		presentationRepository.save(presentation);
 
-		slot1.assignPresentation(presentation);
+//		slot1.assignPresentation(presentation);
 
 		// when
 		int year = now.getYear();
@@ -375,7 +376,7 @@ class AdminPresentationSlotServiceTest {
 				null, false, false, slot);
 
 		presentationRepository.save(presentation);
-		slot.assignPresentation(presentation);
+//		slot.assignPresentation(presentation);
 
 		// when & then
 		assertThatThrownBy(() -> slotService.validateSlotEligibleForRegistration(slot.getId()))

--- a/backend/src/test/java/org/ftclub/cabinet/presentation/repository/PresentationCommentRepositoryTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/presentation/repository/PresentationCommentRepositoryTest.java
@@ -1,0 +1,111 @@
+package org.ftclub.cabinet.presentation.repository;
+
+import java.time.LocalDateTime;
+import org.ftclub.cabinet.presentation.domain.Presentation;
+import org.ftclub.cabinet.presentation.domain.PresentationComment;
+import org.ftclub.cabinet.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import org.ftclub.cabinet.presentation.domain.Category;
+import org.ftclub.cabinet.presentation.domain.Duration;
+import org.ftclub.cabinet.presentation.domain.PresentationLocation;
+import org.ftclub.cabinet.presentation.domain.PresentationSlot;
+
+@DataJpaTest
+@EntityScan("org.ftclub.cabinet")
+class PresentationCommentRepositoryTest {
+
+	@Autowired
+	private TestEntityManager em;
+
+	@Autowired
+	private PresentationCommentRepository presentationCommentRepository;
+
+	// 테스트에서 공통으로 사용할 엔티티 변수 선언
+	private User testUser;
+	private Presentation targetPresentation;
+	private PresentationComment activeComment;
+	private PresentationComment deletedComment;
+
+	@BeforeEach
+	void setUp() {
+		// --- Given ---
+
+		// 1. User 생성 및 영속화
+		testUser = User.of("testUser", "testuser@student.42seoul.kr",
+				LocalDateTime.now().plusDays(100L), "ROLE_USER");
+		em.persist(testUser);
+
+		// 2. PresentationSlot 생성 및 영속화
+		PresentationSlot slot1 = new PresentationSlot(LocalDateTime.now().plusDays(7),
+				PresentationLocation.BASEMENT);
+		em.persist(slot1);
+		PresentationSlot slot2 = new PresentationSlot(LocalDateTime.now().plusDays(8),
+				PresentationLocation.FIRST);
+		em.persist(slot2);
+
+		// 3. Presentation 생성 및 영속화
+		// 3-1. 테스트 대상이 될 발표
+		targetPresentation = Presentation.of(testUser, Category.STUDY, Duration.HOUR,
+				"JPA 완전 정복", "JPA 심층 스터디", "JPA의 기본부터 심화까지", "상세 내용...",
+				"thumbnail-s3-key-1", true, true, slot1);
+		em.persist(targetPresentation);
+
+		// 3-2. 경계값 테스트를 위한 다른 발표 - 조회되지 않는 댓글 생성을 위해 사용
+		Presentation otherPresentation = Presentation.of(testUser, Category.DEVELOP, Duration.HALF,
+				"TDD 시작하기", "TDD 방법론 공유", "TDD의 A to Z", "상세 내용...",
+				"thumbnail-s3-key-2", true, true, slot2);
+		em.persist(otherPresentation);
+
+		// 4. PresentationComment 생성 및 영속화
+		// 4-1. 조회되어야 할 댓글
+		activeComment = new PresentationComment(targetPresentation, testUser, "발표 잘 들었습니다!");
+		em.persist(activeComment);
+
+		// 4-2. `deleted` 플래그가 true인 댓글
+		deletedComment = new PresentationComment(targetPresentation, testUser, "이 댓글은 삭제됨");
+		deletedComment.delete(); // delete() 메서드로 상태 변경
+		em.persist(deletedComment);
+
+		// 4-3. 다른 발표에 달린 댓글 - 조회되지 않아야 함
+		PresentationComment otherComment = new PresentationComment(otherPresentation, testUser,
+				"유익해요");
+		em.persist(otherComment);
+
+		// DB에 변경사항을 즉시 반영하고, 1차 캐시를 비워서 순수한 DB 조회 환경을 만듦
+		em.flush();
+		em.clear();
+	}
+
+	@Test
+	@DisplayName("특정 Presentation ID로 삭제되지 않은 댓글만 생성 시간 오름차순으로 조회")
+	void findByPresentationIdAndDeletedFalseOrderByCreatedAtAsc_성공() {
+		// --- When ---
+		List<PresentationComment> foundComments = presentationCommentRepository
+				.findByPresentationIdAndDeletedFalseOrderByCreatedAtAsc(targetPresentation.getId());
+
+		// --- Then ---
+		// 1. 결과 리스트는 null이 아니며, 크기는 1이어야 한다.
+		assertThat(foundComments).isNotNull().hasSize(1);
+
+		// 2. 조회된 댓글이 activeComment와 일치하는지 검증
+		PresentationComment resultComment = foundComments.get(0);
+		assertThat(resultComment.getId()).isEqualTo(activeComment.getId());
+		assertThat(resultComment.getDetail()).isEqualTo("발표 잘 들었습니다!");
+		assertThat(resultComment.isDeleted()).isFalse();
+
+		// 3. 연관된 Presentation이 올바른지 검증
+		assertThat(resultComment.getPresentation().getId()).isEqualTo(targetPresentation.getId());
+	}
+}

--- a/backend/src/test/java/org/ftclub/cabinet/presentation/repository/PresentationSlotRepositoryTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/presentation/repository/PresentationSlotRepositoryTest.java
@@ -9,10 +9,10 @@ import org.ftclub.cabinet.presentation.domain.PresentationSlot;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest
+@DataJpaTest
 @Transactional
 class PresentationSlotRepositoryTest {
 

--- a/backend/src/test/java/org/ftclub/cabinet/presentation/service/PresentationCommentServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/presentation/service/PresentationCommentServiceTest.java
@@ -229,18 +229,18 @@ class PresentationCommentServiceTest {
 	@DisplayName("특정 발표 댓글 목록 조회 성공 - 여러 댓글")
 	void getCommentsByPresentationId_성공_여러_댓글() {
 		// Given
-		Long requestingUserId = 1L; // 조회 요청하는 사용자 ID
 		Long presentationId = 10L;
-		Long commentOwnerId = 1L;
-		Long anotherUserId = 2L;
+		Long user1Id = 1L;
+		Long user2Id = 2L;
+		Long requestingUserId = user1Id; // 조회 요청하는 사용자 ID
 
 		User ownerUser = mock(User.class);
-		given(ownerUser.getId()).willReturn(commentOwnerId);
+		given(ownerUser.getId()).willReturn(user1Id);
 		given(ownerUser.getName()).willReturn("owner");
 
-		User anotherUser = mock(User.class);
-		given(anotherUser.getId()).willReturn(anotherUserId);
-		given(anotherUser.getName()).willReturn("another");
+		User user2 = mock(User.class);
+		given(user2.getId()).willReturn(user2Id);
+		given(user2.getName()).willReturn("user2");
 
 		LocalDateTime now = LocalDateTime.now();
 		PresentationComment comment1 = mock(PresentationComment.class); // 내 댓글, 수정 안됨, 밴 안됨
@@ -253,13 +253,14 @@ class PresentationCommentServiceTest {
 
 		PresentationComment comment2 = mock(PresentationComment.class); // 다른 사람 댓글, 수정됨, 밴됨
 		given(comment2.getId()).willReturn(102L);
-		given(comment2.getUser()).willReturn(anotherUser);
+		given(comment2.getUser()).willReturn(user2);
 		given(comment2.getCreatedAt()).willReturn(now.minusMinutes(5));
 		given(comment2.getUpdatedAt()).willReturn(now.minusMinutes(1)); // 수정됨
 		given(comment2.isBanned()).willReturn(true); // 밴됨
 
 		List<PresentationComment> mockComments = Arrays.asList(comment1, comment2);
-		given(presentationCommentRepository.findByPresentationIdOrderByCreatedAtAsc(presentationId))
+		given(presentationCommentRepository.findByPresentationIdAndDeletedFalseOrderByCreatedAtAsc(
+				presentationId))
 				.willReturn(mockComments);
 
 		// When
@@ -283,7 +284,7 @@ class PresentationCommentServiceTest {
 		// 두 번째 댓글 검증 (다른 사람 댓글)
 		PresentationCommentResponseDto dto2 = responseDtos.get(1);
 		assertEquals(comment2.getId(), dto2.getCommentId());
-		assertEquals(anotherUser.getName(), dto2.getUser());
+		assertEquals(user2.getName(), dto2.getUser());
 		assertEquals(comment2.getCreatedAt(), dto2.getDateTime());
 		assertFalse(dto2.isMine()); // 요청한 사용자와 댓글 작성자가 다름
 		assertTrue(dto2.isBanned());
@@ -297,7 +298,8 @@ class PresentationCommentServiceTest {
 		Long requestingUserId = 1L;
 		Long presentationId = 11L;
 
-		given(presentationCommentRepository.findByPresentationIdOrderByCreatedAtAsc(presentationId))
+		given(presentationCommentRepository.findByPresentationIdAndDeletedFalseOrderByCreatedAtAsc(
+				presentationId))
 				.willReturn(Collections.emptyList());
 
 		// When

--- a/backend/src/test/java/org/ftclub/cabinet/presentation/service/PresentationSlotServiceTest.java
+++ b/backend/src/test/java/org/ftclub/cabinet/presentation/service/PresentationSlotServiceTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import org.ftclub.cabinet.dto.AvailablePresentationSlotDto;
+import org.ftclub.cabinet.event.RedisExpirationEventListener;
 import org.ftclub.cabinet.presentation.domain.PresentationSlot;
 import org.ftclub.cabinet.presentation.dto.DataListResponseDto;
 import org.ftclub.cabinet.presentation.repository.PresentationRepository;
@@ -34,6 +35,9 @@ class PresentationSlotServiceTest {
 
 	@Autowired
 	private PresentationRepository presentationRepository;
+
+	@MockBean
+	private RedisExpirationEventListener redisExpirationEventListener;
 
 	@MockBean
 	private Clock clock;

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -100,7 +100,7 @@ cabinet:
       extension-delete-time: 0 */5 * * * * # 5분마다
       extension-issue-time: 0 0 0 2 * * # 매월 2일 0시 0분 0초
       section-alarm-time: 0 */5 * * * * # 5분마다
-      generate-presentation-form: 0 0 0 1 * * # 매월 1일 0시 0분 0초
+      generate-presentation-slot: 0 0 0 1 * * # 매월 1일 0시 0분 0초
   #------------------------------CABINET POLICY------------------------------
   policy:
     in-session:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -263,7 +263,7 @@ spring:
 
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:;MODE=MySQL
+    url: jdbc:h2:mem:testdb;MODE=MySQL
     username: root
     password: test_password
 
@@ -274,11 +274,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     properties:
       hibernate:
-        globally_quoted_identifiers: true
-        dialect: org.hibernate.dialect.MySQL5InnoDBDialect
+        auto_quote_keyword: true
         format_sql: true
     defer-datasource-initialization: true
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [ ] FEAT : 새로운 기능 추가 및 개선
- [X] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [X] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [X] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [X] ETC : 테스트의 `application.yml` 에서 H2 설정 변경

## 설명

https://github.com/innovationacademy-kr/42cabi/issues/1806  

### 작업 개요

이번 PR에서는 두 가지 주요 문제를 해결했습니다.

1. **버그 수정**: 발표의 댓글 목록 조회 시, 논리적으로 삭제된 댓글이 필터링되지 않고 그대로 노출되는 문제를 해결했습니다.
    
2. **환경 개선**: 테스트 실행 시 발생하던 H2 데이터베이스 관련 에러를 수정하여 안정적인 테스트 환경을 구축했습니다.


### 주요 변경 사항

**1. 삭제된 댓글 조회 버그 수정**  

- **문제 원인**: 댓글을 조회하는 Repository 메서드가 댓글의 삭제 상태 (`isDeleted`)를 확인하지 않아, 삭제 처리된 댓글까지 모두 가져오고 있었습니다.

- **해결 방안**: `PresentationCommentRepository`의 조회 메서드에 `AndDeletedFalse` 조건을 추가하여, 삭제되지 않은 댓글만 조회하도록 수정했습니다.
    - `findByPresentationIdOrderByCreatedAtAsc` -> `findByPresentationIdAndDeletedFalseOrderByCreatedAtAsc`

- **테스트 추가**: 변경 사항을 명확하게 검증하기 위해 `PresentationCommentRepositoryTest`를 추가했습니다. 이 테스트는 특정 발표에 속한 댓글 중 **삭제된 댓글은 제외하고 활성화된 댓글만** 정상적으로 조회되는지 확인합니다.


**2. 테스트 H2 데이터베이스 에러 해결**  

- **문제 원인**: 테스트에 사용하는 H2 DB에서 `USER`는 예약어(Reserved Word)입니다. 이 때문에 `User` 엔티티 관련 테스트에서 SQL 에러가 발생했습니다.

- **기존 해결책의 문제**: 처음에는 모든 테이블과 컬럼명에 따옴표를 붙이는 `globally_quoted_identifiers: true` 옵션으로 해결하려 했습니다. 하지만 이 방식은 `User` 엔티티의 특정 필드에 사용된 `@Column(columnDefinition = "...")` 속성과 충돌하여, H2에서 유효하지 않은 SQL(`"boolean default true"`)을 생성하는 새로운 문제를 발생시켰습니다.

- **최종 해결 방안**: 모든 식별자에 따옴표를 강제하는 대신, **예약어에 대해서만 따옴표를 자동으로 적용**하는 `spring.jpa.properties.hibernate.auto_quote_keyword: true` 설정으로 변경하여 문제를 해결했습니다.
    
- **의존성 관리**: 테스트 환경의 일관성을 확보하기 위해 `build.gradle`에 H2 데이터베이스 버전을 명시적으로 지정했습니다.


**3. slot 요소 업데이트 시 버그 수정**

- **문제 원인**: 슬롯 수정 시 연결된 Presenation의 슬롯 데이터도 수정을 해야 하는데, 이때 Presentation이 연결되었는지 여부를 확인하지 않아, 연결되지 않은 슬롯들에 대해 `NullPointException` 이 발생하고 있었습니다.

- **해결 방안**: slot 안에 구현되어 있는 `hasPresentation()` 함수를 사용하여 확인 후 다음 로직(`updateSlotDetails`)을 실행하도록 수정했습니다.


**4. test 코드 도커 의존하지 않아도 실행 가능하도록 변경**
- **문제 원인**: 이전까지는 h2 데이터베이스 관련해서 문제를 해결하지 못해, 도커를 돌리고 profile 관련해서 local 임을 명시하여 진행했습니다.

- **의존된 부분 변경**: 위의 2번 문제가 해결됨에 따라 `@SpringBootTest` 관련된 부분을 도커 환경을 실행하지 않아도 스프링 테스트가 가능하도록 변경하였습니다.


### 리뷰어에게

- H2 DB 설정 변경이 다른 테스트에 미치는 영향은 없는지 검토해주시면 감사하겠습니다.

