### PR TITLE
[FE] FEAT: 어드민 수정하기 구현 및 에러처리

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -90,10 +90,7 @@ function App(): React.ReactElement {
               element={<PresentationDetailPage />}
             />
             <Route path="register" element={<RegisterPage />} />
-            <Route
-              path="register/:presentationId"
-              element={<RegisterPage />}
-            />
+            <Route path="register/:presentationId" element={<RegisterPage />} />
             <Route path="about" element={<AboutUsPage />} />
             <Route path="profile" element={<PresentationProfilePage />} />
           </Route>
@@ -113,6 +110,11 @@ function App(): React.ReactElement {
             element={<AdminPresentationLayout />}
           >
             <Route path="home" element={<AdminPresentationHomePage />} />
+            <Route
+              path=":presentationId"
+              element={<PresentationDetailPage />}
+            />
+            <Route path="register/:presentationId" element={<RegisterPage />} />
           </Route>
           <Route path="/login/failure" element={<LoginFailurePage />} />
           <Route

--- a/frontend/src/Cabinet/components/TopNav/TopNavDomainGroup/TopNavDomainGroup.tsx
+++ b/frontend/src/Cabinet/components/TopNav/TopNavDomainGroup/TopNavDomainGroup.tsx
@@ -22,7 +22,8 @@ const domains: ITopNavDomain[] = [
   },
   {
     path: "/presentations/home",
-    adminPath: "/admin/presentations/detail",
+    // adminPath: "/admin/presentations/detail", // detail 페이지에서 axiosGetPresentationById 호출 시 권한부족으로 에러
+    adminPath: "/admin/presentations/home",
     logo: PresentationLogo,
     title: "수요지식회",
     active: (pathname) => pathname.includes("presentations"),

--- a/frontend/src/Presentation/api/axios.custom.ts
+++ b/frontend/src/Presentation/api/axios.custom.ts
@@ -1,131 +1,179 @@
 import instance from "@/Cabinet/api/axios/axios.instance";
+import { getCookie } from "@/Cabinet/api/react_cookie/cookies";
 
-const axiosGetPresentationByIdURL = "/v6/presentations/";
-export const axiosGetPresentationById = async (
-  presentationId: string
-): Promise<any> => {
-  try {
-    const response = await instance.get(
-      `${axiosGetPresentationByIdURL}${presentationId}`
-    );
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
 
-const axiosGetPresentationsSlotURL = "/v6/presentations/slots";
-// const axiosGetPresentationsSlotURL = "/v6/presentations?type=slots";
-export const axiosGetPresentationsSlot = async () => {
-  try {
-    const response = await instance.get(axiosGetPresentationsSlotURL);
-    return response;
-  } catch (error: any) {
-    // 상세한 에러 정보 로깅
-    console.error("API Error Details:", {
-      status: error.response?.status,
-      statusText: error.response?.statusText,
-      data: error.response?.data,
-      headers: error.response?.headers,
-      config: error.config,
-    });
-    throw error;
-  }
-};
 
-const axiosCreatePresentationURL = "/v6/presentations";
-export const axiosCreatePresentation = async (
-  formData: FormData
-): Promise<any> => {
-  try {
-    const response = await instance.post(axiosCreatePresentationURL, formData, {
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
-    });
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
+// 해당 파일에 있는 내용 /axios/ 안으로 복사했음
 
-const axiosUpdatePresentationURL = "/v6/presentations/";
-export const axiosUpdatePresentation = async (
-  presentationId: string,
-  body: any,
-  thumbnailFile: File | null
-): Promise<any> => {
-  try {
-    // console.log("body : ", body);
-    const formData = new FormData();
-    formData.append(
-      "form",
-      new Blob([JSON.stringify(body)], { type: "application/json" })
-    );
-    if (thumbnailFile) {
-      formData.append("thumbnail", thumbnailFile);
-    } 
-    const response = await instance.patch(
-      `/v6/presentations/${presentationId}`,
-      formData,
-      {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      }
-    );
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
 
-const axiosGetPresentationsURL = "/v6/presentations";
-export const axiosGetPresentations = async (
-  category: string = "ALL",
-  sort: string = "TIME",
-  page: number = 0,
-  size: number = 6
-): Promise<any> => {
-  try {
-    const response = await instance.get(axiosGetPresentationsURL, {
-      params: {
-        category,
-        sort,
-        page,
-        size,
-      },
-    });
-    return response;
-  } catch (error) {
-    throw error;
-  }
-};
 
-const axiosPostPresentationLikeURL = "/v6/presentations";;
-export const axiosPostPresentationLike = async (
-  presentationId: string
-): Promise<any> => {
-  try {
-    const response = await instance.post(
-      `${axiosPostPresentationLikeURL}/${presentationId}/likes`
-    );
-    return response;
-  } catch (error) {
-    throw error;
-  }
-}
+// const axiosGetPresentationByIdURL = "/v6/presentations/";
+// export const axiosGetPresentationById = async (
+//   presentationId: string
+// ): Promise<any> => {
+//   try {
+//     const response = await instance.get(
+//       `${axiosGetPresentationByIdURL}${presentationId}`
+//     );
+//     return response;
+//   } catch (error) {
+//     throw error;
+//   }
+// };
 
-const axiosDeletePresentationLikeURL = "/v6/presentations";
-export const axiosDeletePresentationLike = async (
-  presentationId: string
-): Promise<any> => {
-  try {
-    const response = await instance.delete(
-      `${axiosDeletePresentationLikeURL}/${presentationId}/likes`
-    );
-    return response;
-  } catch (error) {
-    throw error;
-  }
-}
+// const axiosGetPresentationsSlotURL = "/v6/presentations/slots";
+// // const axiosGetPresentationsSlotURL = "/v6/presentations?type=slots";
+// export const axiosGetPresentationsSlot = async () => {
+//   try {
+//     const response = await instance.get(axiosGetPresentationsSlotURL);
+//     return response;
+//   } catch (error: any) {
+//     // 상세한 에러 정보 로깅
+//     console.error("API Error Details:", {
+//       status: error.response?.status,
+//       statusText: error.response?.statusText,
+//       data: error.response?.data,
+//       headers: error.response?.headers,
+//       config: error.config,
+//     });
+//     throw error;
+//   }
+// };
+
+// const axiosCreatePresentationURL = "/v6/presentations";
+// export const axiosCreatePresentation = async (
+//   formData: FormData
+// ): Promise<any> => {
+//   try {
+//     const response = await instance.post(axiosCreatePresentationURL, formData, {
+//       headers: {
+//         "Content-Type": "multipart/form-data",
+//       },
+//     });
+//     return response;
+//   } catch (error) {
+//     throw error;
+//   }
+// };
+
+// const axiosUpdatePresentationURL = "/v6/presentations/";
+// export const axiosUpdatePresentation = async (
+//   presentationId: string,
+//   body: any,
+//   thumbnailFile: File | null
+// ): Promise<any> => {
+//   try {
+//     console.log("body : ", body);
+//     const formData = new FormData();
+//     formData.append(
+//       "form",
+//       new Blob([JSON.stringify(body)], { type: "application/json" })
+//     );
+//     if (thumbnailFile) {
+//       formData.append("thumbnail", thumbnailFile);
+//     } 
+//     const response = await instance.patch(
+//       `${axiosUpdatePresentationURL}${presentationId}`,
+//       formData,
+//       {
+//         headers: {
+//           "Content-Type": "multipart/form-data",
+//         },
+//       }
+//     );
+//     return response;
+//   } catch (error) {
+//     console.log("에러여기걸리나")
+//     const err = error as any;
+//     console.error("API Error Details:", {
+//       status: err.response?.status,
+//       statusText: err.response?.statusText,
+//       data: err.response?.data,
+//       headers: err.response?.headers,
+//       config: err.config,
+//     });
+//     throw error;
+//   }
+// };
+// const axiosUpdateAdminPresentationURL = "/v6/admin/presentations/";
+// export const axiosUpdateAdminPresentation = async (
+//   presentationId: string,
+//   body: any,
+//   thumbnailFile: File | null
+// ): Promise<any> => {
+//   try {
+//     console.log("body : ", body);
+//     const accessToken = getCookie("access_token");
+//     const formData = new FormData();
+//     formData.append(
+//       "form",
+//       new Blob([JSON.stringify(body)], { type: "application/json" })
+//     );
+//     if (thumbnailFile) {
+//       formData.append("thumbnail", thumbnailFile);
+//     } 
+//     const response = await instance.patch(
+//       `${axiosUpdateAdminPresentationURL}${presentationId}`,
+//       formData,
+//       {
+//         headers: {
+//           "Content-Type": "multipart/form-data",
+//             Authorization: `Bearer ${accessToken}`,
+//         },
+//       }
+//     );
+//     return response;
+//   } catch (error) {
+//     throw error;
+//   }
+// };
+
+// const axiosGetPresentationsURL = "/v6/presentations";
+// export const axiosGetPresentations = async (
+//   category: string = "ALL",
+//   sort: string = "TIME",
+//   page: number = 0,
+//   size: number = 6
+// ): Promise<any> => {
+//   try {
+//     const response = await instance.get(axiosGetPresentationsURL, {
+//       params: {
+//         category,
+//         sort,
+//         page,
+//         size,
+//       },
+//     });
+//     return response;
+//   } catch (error) {
+//     throw error;
+//   }
+// };
+
+// const axiosPostPresentationLikeURL = "/v6/presentations";;
+// export const axiosPostPresentationLike = async (
+//   presentationId: string
+// ): Promise<any> => {
+//   try {
+//     const response = await instance.post(
+//       `${axiosPostPresentationLikeURL}/${presentationId}/likes`
+//     );
+//     return response;
+//   } catch (error) {
+//     throw error;
+//   }
+// }
+
+// const axiosDeletePresentationLikeURL = "/v6/presentations";
+// export const axiosDeletePresentationLike = async (
+//   presentationId: string
+// ): Promise<any> => {
+//   try {
+//     const response = await instance.delete(
+//       `${axiosDeletePresentationLikeURL}/${presentationId}/likes`
+//     );
+//     return response;
+//   } catch (error) {
+//     throw error;
+//   }
+// }

--- a/frontend/src/Presentation/api/axios.custom.ts
+++ b/frontend/src/Presentation/api/axios.custom.ts
@@ -64,16 +64,7 @@ export const axiosUpdatePresentation = async (
     );
     if (thumbnailFile) {
       formData.append("thumbnail", thumbnailFile);
-      // console.log("추가됨")
-      // formData.append("thumbnailUpdated", "true");
     } 
-    for (const [key, value] of formData.entries()) {
-      if (value instanceof File) {
-        console.log(`${key}: [File] ${value.name}`);
-      } else {
-        console.log(`${key}:`, value);
-      }
-    }
     const response = await instance.patch(
       `/v6/presentations/${presentationId}`,
       formData,

--- a/frontend/src/Presentation/api/axios/axios.custom.ts
+++ b/frontend/src/Presentation/api/axios/axios.custom.ts
@@ -1,3 +1,4 @@
+import { useLocation } from "react-router-dom";
 import instance from "@/Cabinet/api/axios/axios.instance";
 import { getCookie } from "@/Cabinet/api/react_cookie/cookies";
 
@@ -135,15 +136,24 @@ export const axiosGetPresentationById = async (
   presentationId: string
 ): Promise<any> => {
   try {
+    const accessToken = getCookie("access_token");
+    // console.log("axiosGetPresentationById");
+    // // const location = useLocation();
+    // console.log("location.pathname : ",location.pathname)
+    // const isAdminPage: boolean = location.pathname === "/admin/presentations/";
     const response = await instance.get(
-      `${axiosGetPresentationByIdURL}${presentationId}`
+      `${axiosGetPresentationByIdURL}${presentationId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      }
     );
     return response;
   } catch (error) {
     throw error;
   }
 };
-
 
 const axiosGetPresentationCommentsURL = "/v6/presentations/";
 export const axiosGetPresentationComments = async (presentationId: string) => {
@@ -224,7 +234,6 @@ export const axiosGetPresentations = async (
   }
 };
 
-
 const axiosGetPresentationsSlotURL = "/v6/presentations/slots";
 // const axiosGetPresentationsSlotURL = "/v6/presentations?type=slots";
 export const axiosGetPresentationsSlot = async () => {
@@ -275,7 +284,7 @@ export const axiosUpdatePresentation = async (
     );
     if (thumbnailFile) {
       formData.append("thumbnail", thumbnailFile);
-    } 
+    }
     const response = await instance.patch(
       `${axiosUpdatePresentationURL}${presentationId}`,
       formData,
@@ -287,7 +296,7 @@ export const axiosUpdatePresentation = async (
     );
     return response;
   } catch (error) {
-    console.log("에러여기걸리나")
+    console.log("에러여기걸리나");
     const err = error as any;
     console.error("API Error Details:", {
       status: err.response?.status,
@@ -315,14 +324,14 @@ export const axiosUpdateAdminPresentation = async (
     );
     if (thumbnailFile) {
       formData.append("thumbnail", thumbnailFile);
-    } 
+    }
     const response = await instance.patch(
       `${axiosUpdateAdminPresentationURL}${presentationId}`,
       formData,
       {
         headers: {
           "Content-Type": "multipart/form-data",
-            Authorization: `Bearer ${accessToken}`,
+          Authorization: `Bearer ${accessToken}`,
         },
       }
     );
@@ -354,7 +363,7 @@ export const axiosUpdateAdminPresentation = async (
 //   }
 // };
 
-const axiosPostPresentationLikeURL = "/v6/presentations";;
+const axiosPostPresentationLikeURL = "/v6/presentations";
 export const axiosPostPresentationLike = async (
   presentationId: string
 ): Promise<any> => {
@@ -366,7 +375,7 @@ export const axiosPostPresentationLike = async (
   } catch (error) {
     throw error;
   }
-}
+};
 
 const axiosDeletePresentationLikeURL = "/v6/presentations";
 export const axiosDeletePresentationLike = async (
@@ -380,4 +389,4 @@ export const axiosDeletePresentationLike = async (
   } catch (error) {
     throw error;
   }
-}
+};

--- a/frontend/src/Presentation/api/axios/axios.custom.ts
+++ b/frontend/src/Presentation/api/axios/axios.custom.ts
@@ -1,4 +1,5 @@
 import instance from "@/Cabinet/api/axios/axios.instance";
+import { getCookie } from "@/Cabinet/api/react_cookie/cookies";
 
 /**
  * 수요지식회 (구 까비지식회) API
@@ -125,6 +126,10 @@ export const getAdminPresentationSchedule = async (
   }
 };
 
+/**
+ * 수요지식회 리뉴얼 API
+ */
+
 const axiosGetPresentationByIdURL = "/v6/presentations/";
 export const axiosGetPresentationById = async (
   presentationId: string
@@ -139,9 +144,7 @@ export const axiosGetPresentationById = async (
   }
 };
 
-/**
- * 수요지식회 리뉴얼 API
- */
+
 const axiosGetPresentationCommentsURL = "/v6/presentations/";
 export const axiosGetPresentationComments = async (presentationId: string) => {
   try {
@@ -220,3 +223,161 @@ export const axiosGetPresentations = async (
     throw error;
   }
 };
+
+
+const axiosGetPresentationsSlotURL = "/v6/presentations/slots";
+// const axiosGetPresentationsSlotURL = "/v6/presentations?type=slots";
+export const axiosGetPresentationsSlot = async () => {
+  try {
+    const response = await instance.get(axiosGetPresentationsSlotURL);
+    return response;
+  } catch (error: any) {
+    // 상세한 에러 정보 로깅
+    console.error("API Error Details:", {
+      status: error.response?.status,
+      statusText: error.response?.statusText,
+      data: error.response?.data,
+      headers: error.response?.headers,
+      config: error.config,
+    });
+    throw error;
+  }
+};
+
+const axiosCreatePresentationURL = "/v6/presentations";
+export const axiosCreatePresentation = async (
+  formData: FormData
+): Promise<any> => {
+  try {
+    const response = await instance.post(axiosCreatePresentationURL, formData, {
+      headers: {
+        "Content-Type": "multipart/form-data",
+      },
+    });
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+const axiosUpdatePresentationURL = "/v6/presentations/";
+export const axiosUpdatePresentation = async (
+  presentationId: string,
+  body: any,
+  thumbnailFile: File | null
+): Promise<any> => {
+  try {
+    console.log("body : ", body);
+    const formData = new FormData();
+    formData.append(
+      "form",
+      new Blob([JSON.stringify(body)], { type: "application/json" })
+    );
+    if (thumbnailFile) {
+      formData.append("thumbnail", thumbnailFile);
+    } 
+    const response = await instance.patch(
+      `${axiosUpdatePresentationURL}${presentationId}`,
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      }
+    );
+    return response;
+  } catch (error) {
+    console.log("에러여기걸리나")
+    const err = error as any;
+    console.error("API Error Details:", {
+      status: err.response?.status,
+      statusText: err.response?.statusText,
+      data: err.response?.data,
+      headers: err.response?.headers,
+      config: err.config,
+    });
+    throw error;
+  }
+};
+const axiosUpdateAdminPresentationURL = "/v6/admin/presentations/";
+export const axiosUpdateAdminPresentation = async (
+  presentationId: string,
+  body: any,
+  thumbnailFile: File | null
+): Promise<any> => {
+  try {
+    console.log("body : ", body);
+    const accessToken = getCookie("access_token");
+    const formData = new FormData();
+    formData.append(
+      "form",
+      new Blob([JSON.stringify(body)], { type: "application/json" })
+    );
+    if (thumbnailFile) {
+      formData.append("thumbnail", thumbnailFile);
+    } 
+    const response = await instance.patch(
+      `${axiosUpdateAdminPresentationURL}${presentationId}`,
+      formData,
+      {
+        headers: {
+          "Content-Type": "multipart/form-data",
+            Authorization: `Bearer ${accessToken}`,
+        },
+      }
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};
+
+// const axiosGetPresentationsURL = "/v6/presentations";
+// export const axiosGetPresentations = async (
+//   category: string = "ALL",
+//   sort: string = "TIME",
+//   page: number = 0,
+//   size: number = 6
+// ): Promise<any> => {
+//   try {
+//     const response = await instance.get(axiosGetPresentationsURL, {
+//       params: {
+//         category,
+//         sort,
+//         page,
+//         size,
+//       },
+//     });
+//     return response;
+//   } catch (error) {
+//     throw error;
+//   }
+// };
+
+const axiosPostPresentationLikeURL = "/v6/presentations";;
+export const axiosPostPresentationLike = async (
+  presentationId: string
+): Promise<any> => {
+  try {
+    const response = await instance.post(
+      `${axiosPostPresentationLikeURL}/${presentationId}/likes`
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+}
+
+const axiosDeletePresentationLikeURL = "/v6/presentations";
+export const axiosDeletePresentationLike = async (
+  presentationId: string
+): Promise<any> => {
+  try {
+    const response = await instance.delete(
+      `${axiosDeletePresentationLikeURL}/${presentationId}/likes`
+    );
+    return response;
+  } catch (error) {
+    throw error;
+  }
+}

--- a/frontend/src/Presentation/components/RegisterCheckbox.tsx
+++ b/frontend/src/Presentation/components/RegisterCheckbox.tsx
@@ -1,47 +1,62 @@
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Control } from "react-hook-form";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { cn } from "@/lib/utils";
-
+import { Control } from "react-hook-form";
+import { RegisterType } from "../types/enum/presentation.type.enum";
 
 interface RegisterCheckBoxProps {
-    control: Control<any>;
-    name: string;
-    description: string;
-    isEditMode?: boolean
-
+  control: Control<any>;
+  name: string;
+  description: string;
+  isEdit: boolean;
 }
-const RegisterCheckBox: React.FC<RegisterCheckBoxProps> = ({control, name, description, isEditMode}) => {
-    return (
-        <FormField
-        control={control}
-        name={name}
-        render={({ field }) => (
-            <FormItem className="flex flex-row items-center  space-x-3 space-y-0 rounded-md border p-2">
-                <FormControl>
-                  <Checkbox
-                    // disabled=
-                    checked={field.value || false} 
-                    onCheckedChange={isEditMode ? undefined : (checked) => field.onChange(checked)}
-                    className={cn(
-                      "h-5 w-5 border-gray-300",
-                      isEditMode && "cursor-not-allowed opacity-60 "
-                    )}
-                  />
-                </FormControl>
-                <FormMessage />
-                <div className="space-y-1 leading-none ">
-                    <FormLabel className={cn(
-                      "text-black text-sm sm:text-base",
-                      isEditMode && "opacity-40"
-                    )}>
-                    {description}
-                    </FormLabel>
-                </div>
-            </FormItem>
-        )}
-        />
-    );
-}
+const RegisterCheckBox: React.FC<RegisterCheckBoxProps> = ({
+  control,
+  name,
+  description,
+  isEdit,
+}) => {
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className="flex flex-row items-center  space-x-3 space-y-0 rounded-md border p-2">
+          <FormControl>
+            <Checkbox
+              checked={field.value || false}
+              onCheckedChange={
+                isEdit
+                  ? undefined
+                  : (checked) => field.onChange(checked === true)
+              }
+              className={cn(
+                "h-5 w-5 border-gray-300",
+                isEdit && "cursor-not-allowed opacity-60 "
+              )}
+            />
+          </FormControl>
+          <FormMessage />
+          <div className="space-y-1 leading-none ">
+            <FormLabel
+              className={cn(
+                "text-black text-sm sm:text-base",
+                isEdit && "opacity-40"
+              )}
+            >
+              {description}
+            </FormLabel>
+          </div>
+        </FormItem>
+      )}
+    />
+  );
+};
 
 export default RegisterCheckBox;

--- a/frontend/src/Presentation/components/RegisterCheckboxContainer.tsx
+++ b/frontend/src/Presentation/components/RegisterCheckboxContainer.tsx
@@ -1,43 +1,51 @@
+import { Label } from "@radix-ui/react-label";
 import React from "react";
 import { Control } from "react-hook-form";
-import { Label } from "@radix-ui/react-label";
 import RegisterCheckBox from "./RegisterCheckbox";
+import { RegisterType } from "../types/enum/presentation.type.enum";
 
 interface CheckBoxProps {
   name: string;
   description: string;
-  isEditMode?: boolean
+  isEdit: boolean;
 }
-  interface RegisterCheckboxContainerProps {
-    control: Control<any>;
-    title: string;
-    subtitle: string;
-    props: CheckBoxProps[];
+interface RegisterCheckboxContainerProps {
+  control: Control<any>;
+  title: string;
+  subtitle: string;
+  props: CheckBoxProps[];
 }
 
-
-
-const RegisterCheckboxContainer: React.FC<RegisterCheckboxContainerProps> = ({control, title, subtitle, props}) => {
+const RegisterCheckboxContainer: React.FC<RegisterCheckboxContainerProps> = ({
+  control,
+  title,
+  subtitle,
+  props,
+}) => {
   return (
     <div className="w-full">
-      <Label className="text-black text-base font-medium sm:text-lg">{title}</Label>
+      <Label className="text-black text-base font-medium sm:text-lg">
+        {title}
+      </Label>
       <div className="w-full rounded-md bg-white mt-2">
         <div className="p-4 text-sm sm:text-bas">
-          <Label className="block mb-4 text-gray-600 p-3 text-wrap whitespace-pre-line">{subtitle}</Label> 
+          <Label className="block mb-4 text-gray-600 p-3 text-wrap whitespace-pre-line">
+            {subtitle}
+          </Label>
           {/* CHECK: whitespace-pre-line 적용이 안됨 */}
-            {props.map((checkbox, index) => (
-                <RegisterCheckBox
-                key={index}
-                control={control}
-                name={checkbox.name}
-                description={checkbox.description}
-                isEditMode={checkbox.isEditMode}
-                />
-            ))}
+          {props.map((checkbox, index) => (
+            <RegisterCheckBox
+              key={index}
+              control={control}
+              name={checkbox.name}
+              description={checkbox.description}
+              isEdit={checkbox.isEdit} // RegisterType을 그대로 전달
+            />
+          ))}
         </div>
       </div>
     </div>
   );
-}
+};
 
 export default RegisterCheckboxContainer;

--- a/frontend/src/Presentation/components/RegisterDatePicker.tsx
+++ b/frontend/src/Presentation/components/RegisterDatePicker.tsx
@@ -18,7 +18,7 @@ import { ko } from "date-fns/locale";
 import { CalendarIcon, Clock } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
 import { Control } from "react-hook-form";
-import { axiosGetPresentationsSlot } from "../api/axios.custom";
+import { axiosGetPresentationsSlot } from "../api/axios/axios.custom";
 
 interface RegisterDatePickerProps {
   control: Control<any>;

--- a/frontend/src/Presentation/components/RegisterForm.tsx
+++ b/frontend/src/Presentation/components/RegisterForm.tsx
@@ -31,7 +31,7 @@ const MAX_CONTENT = 300;
 
 const contactSchema = z
   .object({
-    mode: z.enum(["CREATE", "EDIT"]), 
+    mode: z.enum(["CREATE", "EDIT"]),
     slotId: z.number().optional(),
     duration: z.string().optional(),
     title: z.string().max(50, "제목은 50자 이하여야 합니다").min(1, "입력없음"),
@@ -179,8 +179,8 @@ const RegisterForm = ({
         outline: data.outline,
         detail: data.detail,
         videoLink: null,
-        isRecordingAllowed: data.recordingAllowed || false,
-        isPublicAllowed: data.publicAllowed || false,
+        recordingAllowed: data.recordingAllowed || false,
+        publicAllowed: data.publicAllowed || false,
         thumbnailUpdated: isThumbnailChanged,
         slotId: data.slotId, // ← 추가
         duration: data.duration, // ← 추가
@@ -205,8 +205,8 @@ const RegisterForm = ({
         summary: data.summary,
         outline: data.outline,
         detail: data.detail,
-        isRecordingAllowed: data.recordingAllowed || false,
-        isPublicAllowed: data.publicAllowed || false,
+        recordingAllowed: data.recordingAllowed || false,
+        publicAllowed: data.publicAllowed || false,
         slotId: data.slotId,
       };
 
@@ -240,6 +240,7 @@ const RegisterForm = ({
     }
   };
   const onFormValidated = (data: z.infer<typeof contactSchema>) => {
+    // console.log("폼 제출 데이터:", data);
     setFormDataToSubmit(data);
     setShowConfirmModal(true);
   };
@@ -258,7 +259,7 @@ const RegisterForm = ({
     setShowConfirmModal(false);
 
     try {
-      //EDIT 
+      //EDIT
       if (isEditMode && presentationId) {
         // PATCH 요청용 body와 파일 분리
         const body = {
@@ -429,13 +430,13 @@ const RegisterForm = ({
               {
                 name: "recordingAllowed",
                 description: "촬영된 영상의 다시보기 제공에 동의합니다.",
-                isEditMode: isEditMode, // edit mode 에서 비활성화
+                isEdit: isEditMode, // EDIT 모드에서만 비활성화
               },
               {
                 name: "publicAllowed",
                 description:
                   "본 영상 및 게시물을 온라인상에 공개하는 것에 동의합니다.",
-                  // "촬영된 영상 및 관련 게시물을 본 기관(42 Seoul) 외부 플랫폼 및 채널에 공개하는 것에 동의합니다.",
+                isEdit: false, // 항상 수정 가능!
               },
             ]}
           />

--- a/frontend/src/Presentation/components/RegisterForm.tsx
+++ b/frontend/src/Presentation/components/RegisterForm.tsx
@@ -8,8 +8,9 @@ import { useNavigate } from "react-router-dom";
 import * as z from "zod";
 import {
   axiosCreatePresentation,
+  axiosUpdateAdminPresentation,
   axiosUpdatePresentation,
-} from "../api/axios.custom";
+} from "../api/axios/axios.custom";
 import {
   PresentationCategoryType,
   RegisterType,
@@ -31,7 +32,7 @@ const MAX_CONTENT = 300;
 
 const contactSchema = z
   .object({
-    mode: z.enum(["CREATE", "EDIT"]),
+    mode: z.nativeEnum(RegisterType),
     slotId: z.number().optional(),
     duration: z.string().optional(),
     title: z.string().max(50, "제목은 50자 이하여야 합니다").min(1, "입력없음"),
@@ -57,6 +58,7 @@ const contactSchema = z
       .refine((file) => !file || file.size <= 5 * 1024 * 1024, {
         message: "이미지는 5MB 이하여야 합니다",
       }),
+    videoLink: z.string().nullable().optional(),
   })
   .superRefine((data, ctx) => {
     if (data.mode === "CREATE") {
@@ -102,17 +104,39 @@ const RegisterForm = ({
     null
   );
   const [thumbnailChanged, setThumbnailChanged] = useState(false);
-  const [thumbnailUpdated, setThumbnailUpdated] = useState(false);
+  // const [thumbnailUpdated, setThumbnailUpdated] = useState(false);
 
   const navigate = useNavigate();
+  const isCreateMode = type === RegisterType.CREATE;
   const isEditMode = type === RegisterType.EDIT;
+  const isAdminMode = type === RegisterType.ADMIN;
+
+  // 각 항목별 수정 가능 여부
+  const canEdit = {
+    date: isCreateMode,
+    time: isCreateMode,
+    category: isCreateMode,
+    title: isCreateMode || isAdminMode,
+    summary: isCreateMode || isEditMode || isAdminMode,
+    outline: isCreateMode || isEditMode || isAdminMode,
+    detail: isCreateMode || isEditMode || isAdminMode,
+    thumbnail: isCreateMode || isEditMode || isAdminMode,
+    videoLink: isAdminMode || isEditMode,
+    recordingAllowed: isCreateMode || isAdminMode,
+    publicAllowed: isCreateMode || isEditMode || isAdminMode,
+  };
 
   const form = useForm({
     resolver: zodResolver(contactSchema),
     defaultValues: {
-      mode: isEditMode ? "EDIT" : "CREATE",
+      mode: isEditMode
+        ? RegisterType.EDIT
+        : isAdminMode
+        ? RegisterType.ADMIN
+        : RegisterType.CREATE,
       slotId: 0,
       duration: undefined,
+      videoLink: "",
       title: "",
       summary: "",
       outline: "",
@@ -129,9 +153,11 @@ const RegisterForm = ({
       setOriginalThumbnail(initialData.data.thumbnailLink);
 
       const editFormDefaultValues = {
-        mode: "EDIT" as const, // 타입을 명확히 지정
+        // mode: "EDIT" as const, // 타입을 명확히 지정
+        mode: isEditMode ? RegisterType.EDIT : RegisterType.ADMIN, // 타입을 명확히 지정
         slotId: initialData.data.slotId ?? 0,
         duration: initialData.data.duration ?? undefined,
+        videoLink: initialData.data.videoLink ?? undefined,
         title: initialData.data.title ?? "",
         summary: initialData.data.summary ?? "",
         outline: initialData.data.outline ?? "",
@@ -144,7 +170,7 @@ const RegisterForm = ({
       form.reset(editFormDefaultValues);
     } else {
       const createFormDefaultValues = {
-        mode: "CREATE" as const, // 모드 추가, 타입 명확히 지정
+        mode: RegisterType.CREATE,
         slotId: 0,
         duration: undefined,
         title: "",
@@ -168,8 +194,7 @@ const RegisterForm = ({
 
   const createFormData = (data: z.infer<typeof contactSchema>) => {
     const formData = new FormData();
-    const isThumbnailChanged =
-      thumbnailChanged || !!formDataToSubmit?.thumbnail;
+    const isThumbnailChanged = thumbnailChanged || !!data?.thumbnail;
     if (isEditMode) {
       // EDIT 모드: PATCH 요청용 데이터
       const requestBody = {
@@ -231,10 +256,12 @@ const RegisterForm = ({
     if (submitSuccess) {
       // 성공했을 때만 페이지 이동
       setTimeout(() => {
-        if (isEditMode) {
-          navigate(`/presentations/${presentationId}`);
+        if (isAdminMode) {
+          navigate(`/admin/presentations/${presentationId}`);
+        } else if (isCreateMode) {
+          navigate(`/presentations/home`);
         } else {
-          navigate("/presentations/home");
+          navigate(`/presentations/${presentationId}`);
         }
       }, 500);
     }
@@ -260,7 +287,7 @@ const RegisterForm = ({
 
     try {
       //EDIT
-      if (isEditMode && presentationId) {
+      if (!isCreateMode && presentationId) {
         // PATCH 요청용 body와 파일 분리
         const body = {
           category: formDataToSubmit.category,
@@ -268,18 +295,26 @@ const RegisterForm = ({
           summary: formDataToSubmit.summary,
           outline: formDataToSubmit.outline,
           detail: formDataToSubmit.detail,
-          videoLink: null,
+          // videoLink: isAdminMode ? formDataToSubmit.videoLink : null,
+          videoLink: formDataToSubmit.videoLink,
           recordingAllowed: formDataToSubmit.recordingAllowed || false,
           publicAllowed: formDataToSubmit.publicAllowed || false,
-          thumbnailUpdated: isEditMode ? thumbnailUpdated : undefined,
+          thumbnailUpdated: thumbnailChanged || undefined,
           duration: formDataToSubmit.duration,
           slotId: 0,
         };
         const thumbnailFile: File | null = formDataToSubmit.thumbnail
           ? (formDataToSubmit.thumbnail as File)
           : null;
-
-        await axiosUpdatePresentation(presentationId, body, thumbnailFile);
+        if (isEditMode) {
+          await axiosUpdatePresentation(presentationId, body, thumbnailFile);
+        } else if (isAdminMode) {
+          await axiosUpdateAdminPresentation(
+            presentationId,
+            body,
+            thumbnailFile
+          );
+        }
         console.log("수정 완료");
       } else {
         // CREATE 로직
@@ -288,42 +323,6 @@ const RegisterForm = ({
         console.log("생성 완료");
       }
 
-      setSubmitSuccess(true);
-      setSubmitError("");
-      setShowResultModal(true);
-    } catch (error: any) {
-      console.error("제출 실패:", error);
-      setSubmitSuccess(false);
-      setSubmitError(
-        error.response?.data?.message || "알 수 없는 오류가 발생했습니다."
-      );
-      setShowResultModal(true);
-    } finally {
-      setIsSubmitting(false);
-      setFormDataToSubmit(null);
-    }
-  };
-
-  const onSubmit = async (data: z.infer<typeof contactSchema>) => {
-    setIsSubmitting(true);
-    setShowConfirmModal(false);
-
-    try {
-      const body = {
-        category: data.category,
-        title: data.title,
-        summary: data.summary,
-        outline: data.outline,
-        detail: data.detail,
-        videoLink: null,
-        recordingAllowed: data.recordingAllowed,
-        publicAllowed: data.publicAllowed,
-        thumbnailUpdated: !thumbnailChanged && !!data.thumbnail,
-        duration: data.duration, // ← 반드시 포함!
-        // slotId 등도 필요하다면 추가
-      };
-      const thumbnailFile = !thumbnailChanged ? data.thumbnail ?? null : null;
-      await axiosUpdatePresentation(presentationId!, body, thumbnailFile);
       setSubmitSuccess(true);
       setSubmitError("");
       setShowResultModal(true);
@@ -352,14 +351,14 @@ const RegisterForm = ({
               control={form.control}
               name="slotId"
               title="날짜"
-              isEditMode={isEditMode}
+              isEditMode={!canEdit.date}
               startTime={startTime}
             />
             <RegisterTimeSelect
               control={form.control}
               name="duration"
               title="소요 시간"
-              isEditMode={isEditMode}
+              isEditMode={!canEdit.time}
             />
           </div>
 
@@ -367,8 +366,19 @@ const RegisterForm = ({
             control={form.control}
             name="category"
             title="카테고리"
-            isEditMode={isEditMode}
+            isEditMode={!canEdit.category}
           />
+
+          {canEdit.videoLink && (
+            <RegisterInput
+              control={form.control}
+              name="videoLink"
+              title="유튜브 링크"
+              maxLength={200}
+              placeholder="발표 영상의 유튜브 url을 입력하세요"
+              isEditMode={!canEdit.videoLink}
+            />
+          )}
 
           <RegisterInput
             control={form.control}
@@ -376,7 +386,7 @@ const RegisterForm = ({
             title="제목"
             maxLength={50}
             placeholder="제목을 입력하세요"
-            isEditMode={isEditMode}
+            isEditMode={!canEdit.title}
           />
 
           <RegisterInput
@@ -385,6 +395,7 @@ const RegisterForm = ({
             title="한 줄 요약"
             maxLength={100}
             placeholder="한 줄 요약을 입력하세요"
+            isEditMode={!canEdit.summary}
           />
 
           <RegisterTextarea
@@ -394,6 +405,7 @@ const RegisterForm = ({
             maxLength={500}
             placeholder="목차를 입력하세요"
             rows={10}
+            isEditMode={!canEdit.outline}
           />
 
           <RegisterTextarea
@@ -403,6 +415,7 @@ const RegisterForm = ({
             maxLength={10000}
             placeholder="내용을 입력하세요"
             rows={10}
+            isEditMode={!canEdit.detail}
           />
 
           <RegisterImageUpload
@@ -412,12 +425,19 @@ const RegisterForm = ({
             maxSize={5}
             accept=".jpg,.jpeg,.png"
             currentImageUrl={originalThumbnail}
+            isEditMode={!canEdit.thumbnail}
             onRemoveFile={() => {
-              if (isEditMode) setThumbnailUpdated(true);
-              // 기존의 setValue(name, null) 등은 RegisterImageUpload에서 처리
+              if (canEdit.thumbnail) {
+                form.setValue("thumbnail", null, {
+                  shouldDirty: true,
+                  shouldTouch: true,
+                  shouldValidate: true,
+                });
+                setThumbnailChanged(true);
+              }
             }}
             onFileUpload={() => {
-              if (isEditMode) setThumbnailUpdated(true);
+              if (canEdit.thumbnail) setThumbnailChanged(true);
             }}
           />
 
@@ -425,18 +445,18 @@ const RegisterForm = ({
             control={form.control}
             title="컨텐츠 촬영 및 공개 동의"
             subtitle={`본 영상 촬영 서비스를 신청하시면, 촬영된 영상은 향후 서비스 이용자들을 위한 다시보기 콘텐츠로 제공됩니다.
-            다음 항목에 대하여 각각의 동의 여부를 선택해주세요.`}
+    다음 항목에 대하여 각각의 동의 여부를 선택해주세요.`}
             props={[
               {
                 name: "recordingAllowed",
                 description: "촬영된 영상의 다시보기 제공에 동의합니다.",
-                isEdit: isEditMode, // EDIT 모드에서만 비활성화
+                isEdit: !canEdit.recordingAllowed,
               },
               {
                 name: "publicAllowed",
                 description:
                   "본 영상 및 게시물을 온라인상에 공개하는 것에 동의합니다.",
-                isEdit: false, // 항상 수정 가능!
+                isEdit: !canEdit.publicAllowed,
               },
             ]}
           />

--- a/frontend/src/Presentation/components/RegisterForm.tsx
+++ b/frontend/src/Presentation/components/RegisterForm.tsx
@@ -121,7 +121,7 @@ const RegisterForm = ({
     outline: isCreateMode || isEditMode || isAdminMode,
     detail: isCreateMode || isEditMode || isAdminMode,
     thumbnail: isCreateMode || isEditMode || isAdminMode,
-    videoLink: isAdminMode || isEditMode,
+    videoLink: isAdminMode ,
     recordingAllowed: isCreateMode || isAdminMode,
     publicAllowed: isCreateMode || isEditMode || isAdminMode,
   };
@@ -203,7 +203,7 @@ const RegisterForm = ({
         summary: data.summary,
         outline: data.outline,
         detail: data.detail,
-        videoLink: null,
+        videoLink: null, // CHECK :
         recordingAllowed: data.recordingAllowed || false,
         publicAllowed: data.publicAllowed || false,
         thumbnailUpdated: isThumbnailChanged,
@@ -295,8 +295,8 @@ const RegisterForm = ({
           summary: formDataToSubmit.summary,
           outline: formDataToSubmit.outline,
           detail: formDataToSubmit.detail,
-          // videoLink: isAdminMode ? formDataToSubmit.videoLink : null,
-          videoLink: formDataToSubmit.videoLink,
+          videoLink: isAdminMode ? formDataToSubmit.videoLink : null, // CHECK :
+          // videoLink: formDataToSubmit.videoLink,
           recordingAllowed: formDataToSubmit.recordingAllowed || false,
           publicAllowed: formDataToSubmit.publicAllowed || false,
           thumbnailUpdated: thumbnailChanged || undefined,

--- a/frontend/src/Presentation/components/RegisterTextarea.tsx
+++ b/frontend/src/Presentation/components/RegisterTextarea.tsx
@@ -1,5 +1,11 @@
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import React from "react";
-import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Control, useFormContext } from "react-hook-form";
 
 interface RegisterTextareaProps {
@@ -9,9 +15,18 @@ interface RegisterTextareaProps {
   maxLength: number;
   placeholder: string;
   rows: number;
+  isEditMode?: boolean; // 추가
 }
 
-const RegisterTextarea: React.FC<RegisterTextareaProps> = ({ control, name, title, maxLength, placeholder, rows }) => {
+const RegisterTextarea: React.FC<RegisterTextareaProps> = ({
+  control,
+  name,
+  title,
+  maxLength,
+  placeholder,
+  rows,
+  isEditMode = false, // 기본값 false
+}) => {
   const { watch } = useFormContext();
   const value = watch(name);
   const textCounter = value?.length || 0;
@@ -22,21 +37,21 @@ const RegisterTextarea: React.FC<RegisterTextareaProps> = ({ control, name, titl
       name={name}
       render={({ field }) => (
         <FormItem className="w-full mb-4">
-          <FormLabel className=" text-black text-base font-medium sm:text-lg">{title}</FormLabel> 
+          <FormLabel className=" text-black text-base font-medium sm:text-lg">
+            {title}
+          </FormLabel>
           <FormControl>
             <textarea
-              // className="flex h-9 w-full rounded-md border border-input bg-white px-3 py-1 text-base  transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground text-base focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm text-left"
               className="w-full box-border rounded-md border-0 bg-white px-3 py-2 text-sm text-base resize-y transition-colors placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
               rows={rows}
               placeholder={placeholder}
               maxLength={maxLength}
+              disabled={isEditMode} // 여기 추가
               {...field}
             />
           </FormControl>
           <div className="flex justify-between text-xs sm:text-sm text-gray-500 mt-1">
-            <span>
-              {/* <FormMessage /> */}
-            </span>
+            <span>{/* <FormMessage /> */}</span>
             <span className={textCounter > maxLength ? "text-red-500" : ""}>
               {textCounter}/{maxLength}
             </span>
@@ -76,9 +91,9 @@ export default RegisterTextarea;
 //                 <FormItem >
 //                 <FormLabel className="text-lg font-bold">{title}</FormLabel>
 //                 <FormControl>
-//                 <textarea 
-//                     className="flex w-[696px] rounded-md border-0 bg-white px-3 py-1 text-sm resize-y text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm text-left" 
-//                     rows={rows} 
+//                 <textarea
+//                     className="flex w-[696px] rounded-md border-0 bg-white px-3 py-1 text-sm resize-y text-base transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm text-left"
+//                     rows={rows}
 //                     placeholder={placeholder}
 //                     maxLength={maxLength}
 //                     {...field}

--- a/frontend/src/Presentation/pages/RegisterPage.tsx
+++ b/frontend/src/Presentation/pages/RegisterPage.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
-import { axiosGetPresentationById } from "../api/axios.custom";
+import { useLocation, useParams } from "react-router-dom";
+import { axiosGetPresentationById } from "../api/axios/axios.custom";
 import { RegisterResultDialog } from "../components/Modals/PresentationResponseModal";
 import RegisterForm from "../components/RegisterForm";
 import { RegisterType } from "../types/enum/presentation.type.enum";
 
 const RegisterPage = () => {
   const { presentationId } = useParams();
+  const location = useLocation();
   const [initialData, setInitialData] = useState(null);
   const [loading, setLoading] = useState(false);
 
@@ -16,6 +17,8 @@ const RegisterPage = () => {
   const [submitSuccess, setSubmitSuccess] = useState(false);
 
   const isEditMode = !!presentationId;
+  // admin 경로 판별
+  const isAdminMode = location.pathname.includes("/admin/");
 
   useEffect(() => {
     if (isEditMode && presentationId) {
@@ -46,18 +49,15 @@ const RegisterPage = () => {
 
   return (
     <div className="w-full h-screen flex flex-col justify-start items-center bg-neutral-100 overflow-y-auto">
-      {/*배너 */}
-      {/* <div className="flex flex-col items-center justify-center bg-blue-500 w-full h-64 flex-shrink-0">
-        <h1 className="font-bold text-4xl text-white">
-          당신의 지식이 누군가의 영감이 됩니다
-        </h1>
-        <p className="font-bold text-xl text-white">
-          모든 지식이 소중합니다. 부담 없이 시작해보세요
-        </p>
-      </div> */}
       <div className="flex-1 w-full flex justify-center">
         <RegisterForm
-          type={isEditMode ? RegisterType.EDIT : RegisterType.CREATE}
+          type={
+            isAdminMode
+              ? RegisterType.ADMIN
+              : isEditMode
+              ? RegisterType.EDIT
+              : RegisterType.CREATE
+          }
           initialData={initialData}
           presentationId={presentationId}
         />

--- a/frontend/src/Presentation/types/enum/presentation.type.enum.ts
+++ b/frontend/src/Presentation/types/enum/presentation.type.enum.ts
@@ -47,4 +47,5 @@ export const PRESENTATION_CATEGORY_LABELS: Record<PresentationCategoryType, stri
 export enum RegisterType {
   CREATE = "CREATE",
   EDIT = "EDIT",
+  ADMIN = "ADMIN",
 } 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [x] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42cabi/issues/738


- [x]  신청하기
    - [x]  신청시 public allowed, recoding allowed 둘 다 체크해도 데이터베이스에 false로 들어감
    - [x]  수정하다가 신청하기 가면 수정하던 발표의 썸네일이 그대로 남아있는 현상
- [x]  어드민 수정하기 
    - admin, create, edit 으로 분기 나누어서 각 권한별 수정 할 수 있는 항목 처리함
    - 유튜브 링크 기입 항목은 어드민 페이지에서만 보이도록 구현, 임시로 수정하기 페이지에서 유튜브 url 수정 권한 주고 테스트 진행함

- 어드민에서 수정하기 페이지(http://localhost/admin/presentations/register/6) 진입 시(**`GET http://localhost/v6/presentations/6` ) 을 호출하는데 어드민 로그인 시** role: `MASTER` 라서 403을 응답받고 있습니다.
- 로그:`Failed to authorize filter invocation [GET /v6/presentations/6] with attributes [hasAnyRole('ROLE_ANONYMOUS','ROLE_USER')]`
- 현재 로그인 사용자의 role: `MASTER`
- 어드민 수정하기 api 요청(`/v6/admin/presentations/{presentation_id}`) 시 302 떠서 api 테스트는 못마쳤습니다. (해당 사항은 최신 common 브랜치 pull 받기 전에 테스트한 사항임)
    - **Spring Security가 컨트롤러에 진입 안시키고 302 Redirect로 `/login` 으로 리다이렉트하는거같음**
    - 로그인 권한 부분 작업(프론트)하면서 처리할 수 있는지 확인해보겠습니다
https://github.com/innovationacademy-kr/42cabi/issues/
